### PR TITLE
Safer stats on macos / Fix for theme values

### DIFF
--- a/library/stats.py
+++ b/library/stats.py
@@ -2,9 +2,10 @@ import os
 
 import GPUtil
 import psutil
-
-if os.name == 'posix':
+try:
     import pyamdgpuinfo
+except ImportError:
+    pyamdgpuinfo = None
 
 import library.config as config
 from library.display import display
@@ -133,11 +134,14 @@ class CPU:
 
     @staticmethod
     def is_temperature_available():
-        if os.name == 'posix':
+        try:
             if 'coretemp' in psutil.sensors_temperatures() or 'k10temp' in psutil.sensors_temperatures():
                 return True
-
-        return False
+            else:
+                return False
+        except AttributeError:
+            # sensors_temperatures may not be available at all
+            return False
 
     @staticmethod
     def temperature():
@@ -299,7 +303,9 @@ class GpuAmd:
 
     @staticmethod
     def is_available():
-        return os.name == 'posix' and pyamdgpuinfo.detect_gpus() > 0
+        if not pyamdgpuinfo:
+            return False
+        return pyamdgpuinfo.detect_gpus() > 0
 
 
 class Memory:

--- a/res/themes/3.5inchTheme2_theme/theme.yaml
+++ b/res/themes/3.5inchTheme2_theme/theme.yaml
@@ -4,7 +4,7 @@ display:
   DISPLAY_ORIENTATION: portrait
 
   # Backplate RGB LED color (for HW revision 'flagship' devices only)
-  DISPLAY_RGB_LED: 0, 0, 255
+  DISPLAY_RGB_LED: [0, 0, 255]
 
 static_images:
   # Specify what static images we want to show on the display


### PR DESCRIPTION
The stats.py module pulls in a package which might not be installed,
and isn't present on my macOS system - the pyamdgpuinfo package. This
change makes the import silent, and allows it to be auto-detected
as absent, rather than failing to run.

Similarly, the psutil package doesn't appear to provide the
sensors_temperature interface, so this has been made safe if it is not
present.

The theme backlight RGB colours was a string, so wouldn't work when passed to the payload.
It just needed to be a list of ints, which meant placing it in square brackets.