### PR TITLE
Replace the queued communications with deferred delays.

### DIFF
--- a/library/display.py
+++ b/library/display.py
@@ -35,13 +35,11 @@ class Display:
         if CONFIG_DATA["display"]["REVISION"] == "A":
             self.lcd = LcdCommRevA(com_port=CONFIG_DATA['config']['COM_PORT'],
                                    display_width=CONFIG_DATA["display"]["DISPLAY_WIDTH"],
-                                   display_height=CONFIG_DATA["display"]["DISPLAY_HEIGHT"],
-                                   update_queue=config.update_queue)
+                                   display_height=CONFIG_DATA["display"]["DISPLAY_HEIGHT"])
         elif CONFIG_DATA["display"]["REVISION"] == "B":
             self.lcd = LcdCommRevB(com_port=CONFIG_DATA['config']['COM_PORT'],
                                    display_width=CONFIG_DATA["display"]["DISPLAY_WIDTH"],
-                                   display_height=CONFIG_DATA["display"]["DISPLAY_HEIGHT"],
-                                   update_queue=config.update_queue)
+                                   display_height=CONFIG_DATA["display"]["DISPLAY_HEIGHT"])
         else:
             logger.error("Unknown display revision '", CONFIG_DATA["display"]["REVISION"], "'")
 

--- a/library/lcd_comm_rev_a.py
+++ b/library/lcd_comm_rev_a.py
@@ -19,9 +19,8 @@ class Command(IntEnum):
 
 
 class LcdCommRevA(LcdComm):
-    def __init__(self, com_port: str = "AUTO", display_width: int = 320, display_height: int = 480,
-                 update_queue: queue.Queue = None):
-        LcdComm.__init__(self, com_port, display_width, display_height, update_queue)
+    def __init__(self, com_port: str = "AUTO", display_width: int = 320, display_height: int = 480):
+        super().__init__(com_port, display_width, display_height)
         self.openSerial()
 
     def __del__(self):
@@ -38,7 +37,13 @@ class LcdCommRevA(LcdComm):
 
         return auto_com_port
 
-    def SendCommand(self, cmd: Command, x: int, y: int, ex: int, ey: int, bypass_queue: bool = False):
+    def SendCommand(self, cmd: Command, x: int, y: int, ex: int, ey: int):
+
+        # Commands must be sent at least 'inter_bitmap_delay' after the bitmap data.
+        delay = (self.last_bitmap_time + self.inter_bitmap_delay) - time.time()
+        if delay > 0:
+            time.sleep(delay)
+
         byteBuffer = bytearray(6)
         byteBuffer[0] = (x >> 2)
         byteBuffer[1] = (((x & 3) << 6) + (y >> 4))
@@ -48,12 +53,7 @@ class LcdCommRevA(LcdComm):
         byteBuffer[5] = cmd
 
         # If no queue for async requests, or if asked explicitly to do the request sequentially: do request now
-        if not self.update_queue or bypass_queue:
-            self.WriteData(byteBuffer)
-        else:
-            # Lock queue mutex then queue the request
-            with self.update_queue_mutex:
-                self.update_queue.put((self.WriteData, [byteBuffer]))
+        self.WriteData(byteBuffer)
 
     def InitializeComm(self):
         # HW revision A does not need init commands
@@ -61,22 +61,29 @@ class LcdCommRevA(LcdComm):
 
     def Reset(self):
         logger.info("Display reset (COM port may change)...")
-        # Reset command bypasses queue because it is run when queue threads are not yet started
-        self.SendCommand(Command.RESET, 0, 0, 0, 0, bypass_queue=True)
-        # Wait for display reset then reconnect
-        time.sleep(1)
-        self.openSerial()
+
+        with self.com_mutex:
+            self.SendCommand(Command.RESET, 0, 0, 0, 0)
+
+            # NOTE: Shouldn't we close serial before we try to open it again ?
+
+            # Wait for display reset then reconnect
+            time.sleep(1)
+            self.openSerial()
 
     def Clear(self):
         self.SetOrientation(Orientation.PORTRAIT)  # Bug: orientation needs to be PORTRAIT before clearing
-        self.SendCommand(Command.CLEAR, 0, 0, 0, 0)
+        with self.com_mutex:
+            self.SendCommand(Command.CLEAR, 0, 0, 0, 0)
         self.SetOrientation()  # Restore default orientation
 
     def ScreenOff(self):
-        self.SendCommand(Command.SCREEN_OFF, 0, 0, 0, 0)
+        with self.com_mutex:
+            self.SendCommand(Command.SCREEN_OFF, 0, 0, 0, 0)
 
     def ScreenOn(self):
-        self.SendCommand(Command.SCREEN_ON, 0, 0, 0, 0)
+        with self.com_mutex:
+            self.SendCommand(Command.SCREEN_ON, 0, 0, 0, 0)
 
     def SetBrightness(self, level: int = 25):
         assert 0 <= level <= 100, 'Brightness level must be [0-100]'
@@ -86,7 +93,8 @@ class LcdCommRevA(LcdComm):
         level_absolute = int(255 - ((level / 100) * 255))
 
         # Level : 0 (brightest) - 255 (darkest)
-        self.SendCommand(Command.SET_BRIGHTNESS, level_absolute, 0, 0, 0)
+        with self.com_mutex:
+            self.SendCommand(Command.SET_BRIGHTNESS, level_absolute, 0, 0, 0)
 
     def SetBackplateLedColor(self, led_color: tuple[int, int, int] = (255, 255, 255)):
         logger.info("HW revision A does not support backplate LED color setting")
@@ -112,7 +120,8 @@ class LcdCommRevA(LcdComm):
         byteBuffer[8] = (width & 255)
         byteBuffer[9] = (height >> 8)
         byteBuffer[10] = (height & 255)
-        self.lcd_serial.write(bytes(byteBuffer))
+        with self.com_mutex:
+            self.lcd_serial.write(bytes(byteBuffer))
 
     def DisplayPILImage(
             self,
@@ -141,13 +150,12 @@ class LcdCommRevA(LcdComm):
         (x0, y0) = (x, y)
         (x1, y1) = (x + image_width - 1, y + image_height - 1)
 
-        self.SendCommand(Command.DISPLAY_BITMAP, x0, y0, x1, y1)
+        with self.com_mutex:
+            self.SendCommand(Command.DISPLAY_BITMAP, x0, y0, x1, y1)
 
-        pix = image.load()
-        line = bytes()
+            pix = image.load()
+            line = bytes()
 
-        # Lock queue mutex then queue all the requests for the image data
-        with self.update_queue_mutex:
             for h in range(image_height):
                 for w in range(image_width):
                     R = pix[w, h][0] >> 3
@@ -159,9 +167,13 @@ class LcdCommRevA(LcdComm):
 
                     # Send image data by multiple of DISPLAY_WIDTH bytes
                     if len(line) >= self.get_width() * 8:
-                        self.SendLine(line)
+                        self.WriteLine(line)
                         line = bytes()
 
             # Write last line if needed
             if len(line) > 0:
-                self.SendLine(line)
+                self.WriteLine(line)
+
+            # There must be a short period between the last write of the bitmap data and the next
+            # command. This seems to be around 0.02s on the flagship device.
+            self.last_bitmap_time = time.time()


### PR DESCRIPTION
The queued communications was, I believe, intended to ensure that
different parts of the system could issues the commands to the
display asynchronously and not have them trample on one another.
However, it was not effective with my flagship device, and almost
never produced an uncorrupted display.

The queue seems unnecessary, and complicates the logic of the
display communications. It has been removed, so that the operations
all happen when they are requested by clients, rather than being
delayed by an arbitrary amount of time by being queued. Instead,
all the operations have been protected by a mutex, similar to the
prior code, but surrounding the entire operation that must be
sequenced in order.

My own investigation implied that there needed to be a delay
between the bitmap data and the next command sent. It's not clear
why, but with this delay in place, the results were never corrupted.

Inserting the delay immediately after the bitmap data send would
work to allow the data to be sent uncorrupted, but it would force
there to always be a delay even when there would be time between
the bitmap and the next command. Instead the delay is deferred
until we try to send the next command - at which point we will
sleep. This means that the delay is amortised into subsequent
work.

The results are solid on my flagship model with a 0.02s delay. It
is possible that this is high, and it could be reduced. It is
possible that this does not work on model A devices, but I cannot
test this at this time. The necessary changes have been made to
the code, but I just have to hope they work.

Here's it working (tested 4 times to be sure):

https://user-images.githubusercontent.com/13813876/188019790-e59c92ab-ec81-43c6-ad4c-8ef49313c79b.mp4
