### PR TITLE
Fix the A rest command.

### DIFF
--- a/library/lcd_comm_rev_a.py
+++ b/library/lcd_comm_rev_a.py
@@ -63,8 +63,9 @@ class LcdCommRevA(LcdComm):
         logger.info("Display reset (COM port may change)...")
         # Reset command bypasses queue because it is run when queue threads are not yet started
         self.SendCommand(Command.RESET, 0, 0, 0, 0, bypass_queue=True)
+        self.closeSerial()
         # Wait for display reset then reconnect
-        time.sleep(1)
+        time.sleep(5)
         self.openSerial()
 
     def Clear(self):

--- a/library/lcd_comm_rev_b.py
+++ b/library/lcd_comm_rev_b.py
@@ -92,6 +92,7 @@ class LcdCommRevB(LcdComm):
 
         if len(response) != 10:
             logger.warning("Device not recognised (short response to HELLO)")
+        assert response, "Device did not return anything"
         if response[0] != Command.HELLO or response[-1] != Command.HELLO:
             logger.warning("Device not recognised (bad framing)")
         if [x for x in response[1:6]] != hello:


### PR DESCRIPTION
You have to close after resetting otherwise the reset forces a different serial port. The kernel won't assign a USB device to a serial port if a program has it open, so it skips to the next available port.