### PR TITLE
Add DateTime but the theme.yaml needs to be filled out

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ config:
   # THEME: Terminal
   # THEME: Landscape6Grid
   # THEME: Cyberpunk
+  # THEME: DateTime
   THEME: 3.5inchTheme2
 
 display:

--- a/library/scheduler.py
+++ b/library/scheduler.py
@@ -139,6 +139,12 @@ def QueueHandler():
         if f:
             f(*args)
 
+@async_job("Date_Stats")
+@schedule(timedelta(seconds=THEME_DATA['STATS']['DATE'].get("INTERVAL", None)).total_seconds())
+def DateStats():
+    # logger.debug("Refresh date stats")
+    stats.Date.stats()
+
 
 def is_queue_empty() -> bool:
     return config.update_queue.empty()

--- a/library/stats.py
+++ b/library/stats.py
@@ -2,6 +2,7 @@ import math
 
 import GPUtil
 import psutil
+import datetime
 
 # AMD GPU on Linux
 try:
@@ -531,4 +532,37 @@ class Disk:
                 background_image=get_full_path(THEME_DATA['PATH'],
                                                THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get("BACKGROUND_IMAGE",
                                                                                                None))
+            )
+
+class Date:
+    @staticmethod
+    def stats():
+        date_now = datetime.datetime.now()
+
+        if THEME_DATA['STATS']['DATE']['DAY']['TEXT'].get("SHOW", False):
+            display.lcd.DisplayText(
+                text=f"{date_now.day}-{date_now.month}-{date_now.year}",
+                x=THEME_DATA['STATS']['DATE']['DAY']['TEXT'].get("X", 0),
+                y=THEME_DATA['STATS']['DATE']['DAY']['TEXT'].get("Y", 0),
+                font=THEME_DATA['STATS']['DATE']['DAY']['TEXT'].get("FONT", "roboto-mono/RobotoMono-Regular.ttf"),
+                font_size=THEME_DATA['STATS']['DATE']['DAY']['TEXT'].get("FONT_SIZE", 10),
+                font_color=THEME_DATA['STATS']['DATE']['DAY']['TEXT'].get("FONT_COLOR", (0, 0, 0)),
+                background_color=THEME_DATA['STATS']['DATE']['DAY']['TEXT'].get("BACKGROUND_COLOR", (255, 255, 255)),
+                background_image=get_full_path(THEME_DATA['PATH'],
+                                               THEME_DATA['STATS']['DATE']['DAY']['TEXT'].get("BACKGROUND_IMAGE",
+                                                                                               None))
+            )
+
+        if THEME_DATA['STATS']['DATE']['HOUR']['TEXT'].get("SHOW", False):
+            display.lcd.DisplayText(
+                text=f"{date_now.strftime('%H:%M:%S')}",
+                x=THEME_DATA['STATS']['DATE']['HOUR']['TEXT'].get("X", 0),
+                y=THEME_DATA['STATS']['DATE']['HOUR']['TEXT'].get("Y", 0),
+                font=THEME_DATA['STATS']['DATE']['HOUR']['TEXT'].get("FONT", "roboto-mono/RobotoMono-Regular.ttf"),
+                font_size=THEME_DATA['STATS']['DATE']['HOUR']['TEXT'].get("FONT_SIZE", 10),
+                font_color=THEME_DATA['STATS']['DATE']['HOUR']['TEXT'].get("FONT_COLOR", (0, 0, 0)),
+                background_color=THEME_DATA['STATS']['DATE']['HOUR']['TEXT'].get("BACKGROUND_COLOR", (255, 255, 255)),
+                background_image=get_full_path(THEME_DATA['PATH'],
+                                               THEME_DATA['STATS']['DATE']['HOUR']['TEXT'].get("BACKGROUND_IMAGE",
+                                                                                                None))
             )

--- a/main.py
+++ b/main.py
@@ -82,3 +82,4 @@ if __name__ == "__main__":
     scheduler.MemoryStats()
     scheduler.DiskStats()
     scheduler.QueueHandler()
+    scheduler.DateStats()

--- a/res/themes/DateTime/theme.yaml
+++ b/res/themes/DateTime/theme.yaml
@@ -1,0 +1,36 @@
+display:
+  # Specify the display orientation for this theme: portrait, landscape, reverse_portrait, reverse_landscape
+  DISPLAY_ORIENTATION: portrait
+
+  # Backplate RGB LED color (for HW revision 'flagship' devices only)
+  DISPLAY_RGB_LED: 0, 0, 255
+
+static_images:
+static_text:
+
+STATS:
+  DATE:
+    # In seconds. Longer intervals cause this to refresh more slowly.
+    # Setting to lower values will display near real time data,
+    # but may cause significant CPU usage or the display not to update properly
+    INTERVAL: 1
+    DAY:
+      TEXT:
+        SHOW: True
+        X: 4
+        Y: 4
+        FONT: roboto-mono/RobotoMono-Regular.ttf
+        FONT_SIZE: 16
+        FONT_COLOR: 53, 191, 92
+        # BACKGROUND_COLOR: 0, 0, 0
+        BACKGROUND_IMAGE: background.png
+    HOUR:
+      TEXT:
+        SHOW: True
+        X: 160
+        Y: 4
+        FONT: roboto-mono/RobotoMono-Regular.ttf
+        FONT_SIZE: 16
+        FONT_COLOR: 53, 191, 92
+        # BACKGROUND_COLOR: 0, 0, 0
+        BACKGROUND_IMAGE: background.png


### PR DESCRIPTION
Also see https://github.com/mathoudebine/turing-smart-screen-python/issues/66 which is why the new DateTime theme doesn't work out of the box.

This code is written by @rollbacke -- I'm just turning it into a PR. https://github.com/mathoudebine/turing-smart-screen-python/issues/32