### PR TITLE
fix text bbox height

### DIFF
--- a/library/lcd/lcd_comm.py
+++ b/library/lcd/lcd_comm.py
@@ -208,12 +208,13 @@ class LcdComm(ABC):
         # Draw text with specified color & font
         font = ImageFont.truetype("./res/fonts/" + font, font_size)
         d = ImageDraw.Draw(text_image)
-        d.text((x, y), text, font=font, fill=font_color)
 
         # Crop text bitmap to keep only the text (also crop if text overflows display)
         left, top, text_width, text_height = d.textbbox((0, 0), text, font=font)
+        d.text((x-left, y-top), text, font=font, fill=font_color)
+        
         text_image = text_image.crop(box=(
-            x + left, y + top,
+            x, y,
             min(x + text_width, self.get_width()),
             min(y + text_height, self.get_height())
         ))

--- a/library/lcd/lcd_comm.py
+++ b/library/lcd/lcd_comm.py
@@ -213,7 +213,7 @@ class LcdComm(ABC):
         # Crop text bitmap to keep only the text (also crop if text overflows display)
         left, top, text_width, text_height = d.textbbox((0, 0), text, font=font)
         text_image = text_image.crop(box=(
-            x, y,
+            x + left, y + top,
             min(x + text_width, self.get_width()),
             min(y + text_height, self.get_height())
         ))


### PR DESCRIPTION
DisplayText bounding box is too high.
Add upleft limits to `box`  option of `crop` method.