### PR TITLE
Improvement of gpu load accuracy using multiple samples on each refresh

### DIFF
--- a/library/stats.py
+++ b/library/stats.py
@@ -26,6 +26,9 @@ import math
 import os
 import platform
 import sys
+import time
+
+from statistics import mean
 
 import babel.dates
 from psutil._common import bytes2human
@@ -374,7 +377,11 @@ def display_gpu_stats(load, memory_percentage, memory_used_mb, temperature):
 class Gpu:
     @staticmethod
     def stats():
-        load, memory_percentage, memory_used_mb, temperature = sensors.Gpu.stats()
+        load_values = []
+        for i in range(100):
+            load, memory_percentage, memory_used_mb, temperature = sensors.Gpu.stats()
+            load_values.append(load)
+        load = mean(load_values)
         display_gpu_stats(load, memory_percentage, memory_used_mb, temperature)
 
     @staticmethod

--- a/library/stats.py
+++ b/library/stats.py
@@ -380,8 +380,12 @@ class Gpu:
         load_values = []
         for i in range(100):
             load, memory_percentage, memory_used_mb, temperature = sensors.Gpu.stats()
-            load_values.append(load)
-        load = mean(load_values)
+            if load != math.nan:
+                load_values.append(load)
+            else:
+                break
+        if load_values:
+            load = mean(load_values)
         display_gpu_stats(load, memory_percentage, memory_used_mb, temperature)
 
     @staticmethod


### PR DESCRIPTION
Hi,

At least on windows with librehardwaremonitor, I feel that gpu load values are not representative with only a single sample taken on each refresh, because there are huge variations and most of the time I get values of 0 or 100%.
I made a modification to instead take 100 consecutive samples each time and using the mean value of those 100 samples. This way we get values much closer to what we can get in the task manager or other monitoring tool (e.g. hwinfo) and probably more accurate. I guess it probably won't hurt either for linux and macos.