### PR TITLE
Multiple disks support

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -68,7 +68,6 @@ def load_theme():
     if THEME_DATA['STATS']['DISK'].get("MOUNTS", False):
         for mount in THEME_DATA['STATS']['DISK']['MOUNTS']:
             mountpoint = [k for k, v in mount.items()][0]
-            print(mountpoint)
             copy_default(THEME_DISK_DEFAULT, mount[mountpoint])
 
 # Load theme on import

--- a/library/config.py
+++ b/library/config.py
@@ -36,6 +36,7 @@ def load_yaml(configfile):
 PATH = sys.path[0]
 CONFIG_DATA = load_yaml("config.yaml")
 THEME_DEFAULT = load_yaml("res/themes/default.yaml")
+THEME_DISK_DEFAULT = load_yaml("res/themes/default_disk.yaml")
 THEME_DATA = None
 
 
@@ -64,6 +65,11 @@ def load_theme():
 
     copy_default(THEME_DEFAULT, THEME_DATA)
 
+    if THEME_DATA['STATS']['DISK'].get("MOUNTS", False):
+        for mount in THEME_DATA['STATS']['DISK']['MOUNTS']:
+            mountpoint = [k for k, v in mount.items()][0]
+            print(mountpoint)
+            copy_default(THEME_DISK_DEFAULT, mount[mountpoint])
 
 # Load theme on import
 load_theme()

--- a/library/sensors/sensors.py
+++ b/library/sensors/sensors.py
@@ -87,17 +87,17 @@ class Memory(ABC):
 class Disk(ABC):
     @staticmethod
     @abstractmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path) -> float:
         pass
 
     @staticmethod
     @abstractmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path) -> int:  # In bytes
         pass
 
     @staticmethod
     @abstractmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path) -> int:  # In bytes
         pass
 
 

--- a/library/sensors/sensors_librehardwaremonitor.py
+++ b/library/sensors/sensors_librehardwaremonitor.py
@@ -341,16 +341,16 @@ class Memory(sensors.Memory):
 # This is because LHM is a hardware-oriented library, whereas used/free/total space is for partitions, not disks
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
-        return psutil.disk_usage("/").percent
+    def disk_usage_percent(path) -> float:
+        return psutil.disk_usage(path).percent
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
-        return psutil.disk_usage("/").used
+    def disk_used(path) -> int:  # In bytes
+        return psutil.disk_usage(path).used
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
-        return psutil.disk_usage("/").free
+    def disk_free(path) -> int:  # In bytes
+        return psutil.disk_usage(path).free
 
 
 class Net(sensors.Net):

--- a/library/sensors/sensors_python.py
+++ b/library/sensors/sensors_python.py
@@ -255,16 +255,16 @@ class Memory(sensors.Memory):
 
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
-        return psutil.disk_usage("/").percent
+    def disk_usage_percent(path) -> float:
+        return psutil.disk_usage(path).percent
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
-        return psutil.disk_usage("/").used
+    def disk_used(path) -> int:  # In bytes
+        return psutil.disk_usage(path).used
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
-        return psutil.disk_usage("/").free
+    def disk_free(path) -> int:  # In bytes
+        return psutil.disk_usage(path).free
 
 
 class Net(sensors.Net):

--- a/library/sensors/sensors_stub_random.py
+++ b/library/sensors/sensors_stub_random.py
@@ -77,15 +77,15 @@ class Memory(sensors.Memory):
 
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path) -> float:
         return random.uniform(0, 100)
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path) -> int:  # In bytes
         return random.randint(1000000000, 2000000000000)
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path) -> int:  # In bytes
         return random.randint(1000000000, 2000000000000)
 
 

--- a/library/sensors/sensors_stub_static.py
+++ b/library/sensors/sensors_stub_static.py
@@ -88,15 +88,15 @@ class Memory(sensors.Memory):
 
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path) -> float:
         return PERCENTAGE_SENSOR_VALUE
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path) -> int:  # In bytes
         return int(DISK_TOTAL_SIZE_GB / 100 * PERCENTAGE_SENSOR_VALUE) * 1000000000
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path) -> int:  # In bytes
         return int(DISK_TOTAL_SIZE_GB / 100 * (100 - PERCENTAGE_SENSOR_VALUE)) * 1000000000
 
 

--- a/library/stats.py
+++ b/library/stats.py
@@ -495,110 +495,116 @@ class Memory:
 class Disk:
     @staticmethod
     def stats():
-        used = sensors.Disk.disk_used()
-        free = sensors.Disk.disk_free()
-        if config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("SHOW", False):
-            display.lcd.DisplayProgressBar(
-                x=config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("X", 0),
-                y=config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("Y", 0),
-                width=config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("WIDTH", 0),
-                height=config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("HEIGHT", 0),
-                value=int(sensors.Disk.disk_usage_percent()),
-                min_value=config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("MIN_VALUE", 0),
-                max_value=config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("MAX_VALUE", 100),
-                bar_color=config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("BAR_COLOR", (0, 0, 0)),
-                bar_outline=config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("BAR_OUTLINE", False),
-                background_color=config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get("BACKGROUND_COLOR",
-                                                                                         (255, 255, 255)),
-                background_image=get_full_path(config.THEME_DATA['PATH'],
-                                               config.THEME_DATA['STATS']['DISK']['USED']['GRAPH'].get(
-                                                   "BACKGROUND_IMAGE",
-                                                   None))
-            )
+        if config.THEME_DATA['STATS']['DISK'].get("MOUNTS", False):
+            for mount in config.THEME_DATA['STATS']['DISK']['MOUNTS']:
+                mountpoint = [k for k, v in mount.items()][0]
+                if not os.path.exists(mountpoint):
+                    logger.warning('Invalid mount point in config: "%s"' % mountpoint)
+                else:
+                    used = sensors.Disk.disk_used(mountpoint)
+                    free = sensors.Disk.disk_free(mountpoint)
+                    if mount[mountpoint]['USED']['GRAPH'].get("SHOW", False):
+                        display.lcd.DisplayProgressBar(
+                            x=mount[mountpoint]['USED']['GRAPH'].get("X", 0),
+                            y=mount[mountpoint]['USED']['GRAPH'].get("Y", 0),
+                            width=mount[mountpoint]['USED']['GRAPH'].get("WIDTH", 0),
+                            height=mount[mountpoint]['USED']['GRAPH'].get("HEIGHT", 0),
+                            value=int(sensors.Disk.disk_usage_percent(mountpoint)),
+                            min_value=mount[mountpoint]['USED']['GRAPH'].get("MIN_VALUE", 0),
+                            max_value=mount[mountpoint]['USED']['GRAPH'].get("MAX_VALUE", 100),
+                            bar_color=mount[mountpoint]['USED']['GRAPH'].get("BAR_COLOR", (0, 0, 0)),
+                            bar_outline=mount[mountpoint]['USED']['GRAPH'].get("BAR_OUTLINE", False),
+                            background_color=mount[mountpoint]['USED']['GRAPH'].get("BACKGROUND_COLOR",
+                                                                                                     (255, 255, 255)),
+                            background_image=get_full_path(config.THEME_DATA['PATH'],
+                                                           mount[mountpoint]['USED']['GRAPH'].get(
+                                                               "BACKGROUND_IMAGE",
+                                                               None))
+                        )
 
-        if config.THEME_DATA['STATS']['DISK']['USED']['TEXT'].get("SHOW", False):
-            used_text = f"{int(used / 1000000000):>5}"
-            if config.THEME_DATA['STATS']['DISK']['USED']['TEXT'].get("SHOW_UNIT", True):
-                used_text += " G"
+                    if mount[mountpoint]['USED']['TEXT'].get("SHOW", False):
+                        used_text = f"{int(used / 1000000000):>5}"
+                        if mount[mountpoint]['USED']['TEXT'].get("SHOW_UNIT", True):
+                            used_text += " G"
 
-            display.lcd.DisplayText(
-                text=used_text,
-                x=config.THEME_DATA['STATS']['DISK']['USED']['TEXT'].get("X", 0),
-                y=config.THEME_DATA['STATS']['DISK']['USED']['TEXT'].get("Y", 0),
-                font=config.THEME_DATA['STATS']['DISK']['USED']['TEXT'].get("FONT",
-                                                                            "roboto-mono/RobotoMono-Regular.ttf"),
-                font_size=config.THEME_DATA['STATS']['DISK']['USED']['TEXT'].get("FONT_SIZE", 10),
-                font_color=config.THEME_DATA['STATS']['DISK']['USED']['TEXT'].get("FONT_COLOR", (0, 0, 0)),
-                background_color=config.THEME_DATA['STATS']['DISK']['USED']['TEXT'].get("BACKGROUND_COLOR",
-                                                                                        (255, 255, 255)),
-                background_image=get_full_path(config.THEME_DATA['PATH'],
-                                               config.THEME_DATA['STATS']['DISK']['USED']['TEXT'].get(
-                                                   "BACKGROUND_IMAGE",
-                                                   None))
-            )
+                        display.lcd.DisplayText(
+                            text=used_text,
+                            x=mount[mountpoint]['USED']['TEXT'].get("X", 0),
+                            y=mount[mountpoint]['USED']['TEXT'].get("Y", 0),
+                            font=mount[mountpoint]['USED']['TEXT'].get("FONT",
+                                                                                        "roboto-mono/RobotoMono-Regular.ttf"),
+                            font_size=mount[mountpoint]['USED']['TEXT'].get("FONT_SIZE", 10),
+                            font_color=mount[mountpoint]['USED']['TEXT'].get("FONT_COLOR", (0, 0, 0)),
+                            background_color=mount[mountpoint]['USED']['TEXT'].get("BACKGROUND_COLOR",
+                                                                                                    (255, 255, 255)),
+                            background_image=get_full_path(config.THEME_DATA['PATH'],
+                                                           mount[mountpoint]['USED']['TEXT'].get(
+                                                               "BACKGROUND_IMAGE",
+                                                               None))
+                        )
 
-        if config.THEME_DATA['STATS']['DISK']['USED']['PERCENT_TEXT'].get("SHOW", False):
-            percent_text = f"{int(sensors.Disk.disk_usage_percent()):>3}"
-            if config.THEME_DATA['STATS']['DISK']['USED']['PERCENT_TEXT'].get("SHOW_UNIT", True):
-                percent_text += "%"
+                    if mount[mountpoint]['USED']['PERCENT_TEXT'].get("SHOW", False):
+                        percent_text = f"{int(sensors.Disk.disk_usage_percent(mountpoint)):>3}"
+                        if mount[mountpoint]['USED']['PERCENT_TEXT'].get("SHOW_UNIT", True):
+                            percent_text += "%"
 
-            display.lcd.DisplayText(
-                text=percent_text,
-                x=config.THEME_DATA['STATS']['DISK']['USED']['PERCENT_TEXT'].get("X", 0),
-                y=config.THEME_DATA['STATS']['DISK']['USED']['PERCENT_TEXT'].get("Y", 0),
-                font=config.THEME_DATA['STATS']['DISK']['USED']['PERCENT_TEXT'].get("FONT",
-                                                                                    "roboto-mono/RobotoMono-Regular.ttf"),
-                font_size=config.THEME_DATA['STATS']['DISK']['USED']['PERCENT_TEXT'].get("FONT_SIZE", 10),
-                font_color=config.THEME_DATA['STATS']['DISK']['USED']['PERCENT_TEXT'].get("FONT_COLOR", (0, 0, 0)),
-                background_color=config.THEME_DATA['STATS']['DISK']['USED']['PERCENT_TEXT'].get("BACKGROUND_COLOR",
-                                                                                                (255, 255, 255)),
-                background_image=get_full_path(config.THEME_DATA['PATH'],
-                                               config.THEME_DATA['STATS']['DISK']['USED']['PERCENT_TEXT'].get(
-                                                   "BACKGROUND_IMAGE",
-                                                   None))
-            )
+                        display.lcd.DisplayText(
+                            text=percent_text,
+                            x=mount[mountpoint]['USED']['PERCENT_TEXT'].get("X", 0),
+                            y=mount[mountpoint]['USED']['PERCENT_TEXT'].get("Y", 0),
+                            font=mount[mountpoint]['USED']['PERCENT_TEXT'].get("FONT",
+                                                                                                "roboto-mono/RobotoMono-Regular.ttf"),
+                            font_size=mount[mountpoint]['USED']['PERCENT_TEXT'].get("FONT_SIZE", 10),
+                            font_color=mount[mountpoint]['USED']['PERCENT_TEXT'].get("FONT_COLOR", (0, 0, 0)),
+                            background_color=mount[mountpoint]['USED']['PERCENT_TEXT'].get("BACKGROUND_COLOR",
+                                                                                                            (255, 255, 255)),
+                            background_image=get_full_path(config.THEME_DATA['PATH'],
+                                                           mount[mountpoint]['USED']['PERCENT_TEXT'].get(
+                                                               "BACKGROUND_IMAGE",
+                                                               None))
+                        )
 
-        if config.THEME_DATA['STATS']['DISK']['TOTAL']['TEXT'].get("SHOW", False):
-            total_text = f"{int((free + used) / 1000000000):>5}"
-            if config.THEME_DATA['STATS']['DISK']['TOTAL']['TEXT'].get("SHOW_UNIT", True):
-                total_text += " G"
+                    if mount[mountpoint]['TOTAL']['TEXT'].get("SHOW", False):
+                        total_text = f"{int((free + used) / 1000000000):>5}"
+                        if mount[mountpoint]['TOTAL']['TEXT'].get("SHOW_UNIT", True):
+                            total_text += " G"
 
-            display.lcd.DisplayText(
-                text=total_text,
-                x=config.THEME_DATA['STATS']['DISK']['TOTAL']['TEXT'].get("X", 0),
-                y=config.THEME_DATA['STATS']['DISK']['TOTAL']['TEXT'].get("Y", 0),
-                font=config.THEME_DATA['STATS']['DISK']['TOTAL']['TEXT'].get("FONT",
-                                                                             "roboto-mono/RobotoMono-Regular.ttf"),
-                font_size=config.THEME_DATA['STATS']['DISK']['TOTAL']['TEXT'].get("FONT_SIZE", 10),
-                font_color=config.THEME_DATA['STATS']['DISK']['TOTAL']['TEXT'].get("FONT_COLOR", (0, 0, 0)),
-                background_color=config.THEME_DATA['STATS']['DISK']['TOTAL']['TEXT'].get("BACKGROUND_COLOR",
-                                                                                         (255, 255, 255)),
-                background_image=get_full_path(config.THEME_DATA['PATH'],
-                                               config.THEME_DATA['STATS']['DISK']['TOTAL']['TEXT'].get(
-                                                   "BACKGROUND_IMAGE",
-                                                   None))
-            )
+                        display.lcd.DisplayText(
+                            text=total_text,
+                            x=mount[mountpoint]['TOTAL']['TEXT'].get("X", 0),
+                            y=mount[mountpoint]['TOTAL']['TEXT'].get("Y", 0),
+                            font=mount[mountpoint]['TOTAL']['TEXT'].get("FONT",
+                                                                                         "roboto-mono/RobotoMono-Regular.ttf"),
+                            font_size=mount[mountpoint]['TOTAL']['TEXT'].get("FONT_SIZE", 10),
+                            font_color=mount[mountpoint]['TOTAL']['TEXT'].get("FONT_COLOR", (0, 0, 0)),
+                            background_color=mount[mountpoint]['TOTAL']['TEXT'].get("BACKGROUND_COLOR",
+                                                                                                     (255, 255, 255)),
+                            background_image=get_full_path(config.THEME_DATA['PATH'],
+                                                           mount[mountpoint]['TOTAL']['TEXT'].get(
+                                                               "BACKGROUND_IMAGE",
+                                                               None))
+                        )
 
-        if config.THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get("SHOW", False):
-            free_text = f"{int(free / 1000000000):>5}"
-            if config.THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get("SHOW_UNIT", True):
-                free_text += " G"
+                    if mount[mountpoint]['FREE']['TEXT'].get("SHOW", False):
+                        free_text = f"{int(free / 1000000000):>5}"
+                        if mount[mountpoint]['FREE']['TEXT'].get("SHOW_UNIT", True):
+                            free_text += " G"
 
-            display.lcd.DisplayText(
-                text=free_text,
-                x=config.THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get("X", 0),
-                y=config.THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get("Y", 0),
-                font=config.THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get("FONT",
-                                                                            "roboto-mono/RobotoMono-Regular.ttf"),
-                font_size=config.THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get("FONT_SIZE", 10),
-                font_color=config.THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get("FONT_COLOR", (0, 0, 0)),
-                background_color=config.THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get("BACKGROUND_COLOR",
-                                                                                        (255, 255, 255)),
-                background_image=get_full_path(config.THEME_DATA['PATH'],
-                                               config.THEME_DATA['STATS']['DISK']['FREE']['TEXT'].get(
-                                                   "BACKGROUND_IMAGE",
-                                                   None))
-            )
+                        display.lcd.DisplayText(
+                            text=free_text,
+                            x=mount[mountpoint]['FREE']['TEXT'].get("X", 0),
+                            y=mount[mountpoint]['FREE']['TEXT'].get("Y", 0),
+                            font=mount[mountpoint]['FREE']['TEXT'].get("FONT",
+                                                                                        "roboto-mono/RobotoMono-Regular.ttf"),
+                            font_size=mount[mountpoint]['FREE']['TEXT'].get("FONT_SIZE", 10),
+                            font_color=mount[mountpoint]['FREE']['TEXT'].get("FONT_COLOR", (0, 0, 0)),
+                            background_color=mount[mountpoint]['FREE']['TEXT'].get("BACKGROUND_COLOR",
+                                                                                                    (255, 255, 255)),
+                            background_image=get_full_path(config.THEME_DATA['PATH'],
+                                                           mount[mountpoint]['FREE']['TEXT'].get(
+                                                               "BACKGROUND_IMAGE",
+                                                               None))
+                        )
 
 
 class Net:

--- a/res/themes/3.5inchTheme2/theme.yaml
+++ b/res/themes/3.5inchTheme2/theme.yaml
@@ -158,47 +158,49 @@ STATS:
         BACKGROUND_COLOR: 132, 154, 165
   DISK:
     INTERVAL: 10
-    USED:
-      GRAPH:
-        SHOW: True
-        X: 155
-        Y: 345
-        WIDTH: 150
-        HEIGHT: 15
-        MIN_VALUE: 0
-        MAX_VALUE: 100
-        BAR_COLOR: 0, 0, 255
-        BAR_OUTLINE: False
-        BACKGROUND_COLOR: 0, 0, 0
-      TEXT:
-        SHOW: TRUE
-        SHOW_UNIT: True
-        X: 204
-        Y: 411
-        FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
-        FONT_SIZE: 23
-        FONT_COLOR: 255, 255, 255
-        BACKGROUND_COLOR: 132, 154, 165
-    TOTAL:
-      TEXT:
-        SHOW: TRUE
-        SHOW_UNIT: True
-        X: 204
-        Y: 381
-        FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
-        FONT_SIZE: 23
-        FONT_COLOR: 255, 255, 255
-        BACKGROUND_COLOR: 132, 154, 165
-    FREE:
-      TEXT:
-        SHOW: TRUE
-        SHOW_UNIT: True
-        X: 204
-        Y: 441
-        FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
-        FONT_SIZE: 23
-        FONT_COLOR: 255, 255, 255
-        BACKGROUND_COLOR: 132, 154, 165
+    MOUNTS:
+      - "/":
+          USED:
+            GRAPH:
+              SHOW: True
+              X: 155
+              Y: 345
+              WIDTH: 150
+              HEIGHT: 15
+              MIN_VALUE: 0
+              MAX_VALUE: 100
+              BAR_COLOR: 0, 0, 255
+              BAR_OUTLINE: False
+              BACKGROUND_COLOR: 0, 0, 0
+            TEXT:
+              SHOW: TRUE
+              SHOW_UNIT: True
+              X: 204
+              Y: 411
+              FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
+              FONT_SIZE: 23
+              FONT_COLOR: 255, 255, 255
+              BACKGROUND_COLOR: 132, 154, 165
+          TOTAL:
+            TEXT:
+              SHOW: TRUE
+              SHOW_UNIT: True
+              X: 204
+              Y: 381
+              FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
+              FONT_SIZE: 23
+              FONT_COLOR: 255, 255, 255
+              BACKGROUND_COLOR: 132, 154, 165
+          FREE:
+            TEXT:
+              SHOW: TRUE
+              SHOW_UNIT: True
+              X: 204
+              Y: 441
+              FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
+              FONT_SIZE: 23
+              FONT_COLOR: 255, 255, 255
+              BACKGROUND_COLOR: 132, 154, 165
 
   DATE:
     INTERVAL: 1

--- a/res/themes/Cyberpunk-net/theme.yaml
+++ b/res/themes/Cyberpunk-net/theme.yaml
@@ -191,16 +191,18 @@ STATS:
         BACKGROUND_IMAGE: background.png
   DISK:
     INTERVAL: 10
-    USED:
-      PERCENT_TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 170
-        Y: 430
-        FONT: generale-mono/GeneraleMonoA.ttf
-        FONT_SIZE: 30
-        FONT_COLOR: 2, 216, 243
-        BACKGROUND_IMAGE: background.png
+    MOUNTS:
+      - "/":
+          USED:
+            PERCENT_TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 170
+              Y: 430
+              FONT: generale-mono/GeneraleMonoA.ttf
+              FONT_SIZE: 30
+              FONT_COLOR: 2, 216, 243
+              BACKGROUND_IMAGE: background.png
   NET:
     INTERVAL: 1
     ETH:

--- a/res/themes/Cyberpunk/theme.yaml
+++ b/res/themes/Cyberpunk/theme.yaml
@@ -183,35 +183,37 @@ STATS:
         BACKGROUND_IMAGE: background.png
   DISK:
     INTERVAL: 10
-    USED:
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 155
-        Y: 338
-        FONT: generale-mono/GeneraleMonoA.ttf
-        FONT_SIZE: 26
-        FONT_COLOR: 2, 216, 243
-        BACKGROUND_IMAGE: background.png
-      PERCENT_TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 170
-        Y: 430
-        FONT: generale-mono/GeneraleMonoA.ttf
-        FONT_SIZE: 30
-        FONT_COLOR: 2, 216, 243
-        BACKGROUND_IMAGE: background.png
-    FREE:
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 155
-        Y: 383
-        FONT: generale-mono/GeneraleMonoA.ttf
-        FONT_SIZE: 26
-        FONT_COLOR: 2, 216, 243
-        BACKGROUND_IMAGE: background.png
+    MOUNTS:
+      - "/":
+          USED:
+            TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 155
+              Y: 338
+              FONT: generale-mono/GeneraleMonoA.ttf
+              FONT_SIZE: 26
+              FONT_COLOR: 2, 216, 243
+              BACKGROUND_IMAGE: background.png
+            PERCENT_TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 170
+              Y: 430
+              FONT: generale-mono/GeneraleMonoA.ttf
+              FONT_SIZE: 30
+              FONT_COLOR: 2, 216, 243
+              BACKGROUND_IMAGE: background.png
+          FREE:
+            TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 155
+              Y: 383
+              FONT: generale-mono/GeneraleMonoA.ttf
+              FONT_SIZE: 26
+              FONT_COLOR: 2, 216, 243
+              BACKGROUND_IMAGE: background.png
   DATE:
     INTERVAL: 1
     DAY:

--- a/res/themes/LandscapeMagicBlue/theme.yaml
+++ b/res/themes/LandscapeMagicBlue/theme.yaml
@@ -147,27 +147,29 @@ STATS:
         BACKGROUND_IMAGE: background.png
   DISK:
     INTERVAL: 10
-    USED:
-      GRAPH:
-        SHOW: True
-        X: 352
-        Y: 93
-        WIDTH: 110
-        HEIGHT: 7
-        MIN_VALUE: 0
-        MAX_VALUE: 100
-        BAR_COLOR: 82, 255, 255
-        BAR_OUTLINE: False
-        BACKGROUND_IMAGE: background.png
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 390
-        Y: 65
-        FONT: generale-mono/GeneraleMonoA.ttf
-        FONT_SIZE: 16
-        FONT_COLOR: 128, 255, 255
-        BACKGROUND_IMAGE: background.png
+    MOUNTS:
+      - "/":
+          USED:
+            GRAPH:
+              SHOW: True
+              X: 352
+              Y: 93
+              WIDTH: 110
+              HEIGHT: 7
+              MIN_VALUE: 0
+              MAX_VALUE: 100
+              BAR_COLOR: 82, 255, 255
+              BAR_OUTLINE: False
+              BACKGROUND_IMAGE: background.png
+            TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 390
+              Y: 65
+              FONT: generale-mono/GeneraleMonoA.ttf
+              FONT_SIZE: 16
+              FONT_COLOR: 128, 255, 255
+              BACKGROUND_IMAGE: background.png
   NET:
     INTERVAL: 1
     ETH:

--- a/res/themes/Terminal/theme.yaml
+++ b/res/themes/Terminal/theme.yaml
@@ -141,18 +141,20 @@ STATS:
         BACKGROUND_COLOR: 0, 0, 0
   DISK:
     INTERVAL: 10
-    USED:
-      GRAPH:
-        SHOW: True
-        X: 115
-        Y: 357
-        WIDTH: 178
-        HEIGHT: 13
-        MIN_VALUE: 0
-        MAX_VALUE: 100
-        BAR_COLOR: 255, 0, 0
-        BAR_OUTLINE: False
-        BACKGROUND_COLOR: 0, 0, 0
+    MOUNTS:
+      - "/":
+          USED:
+            GRAPH:
+              SHOW: True
+              X: 115
+              Y: 357
+              WIDTH: 178
+              HEIGHT: 13
+              MIN_VALUE: 0
+              MAX_VALUE: 100
+              BAR_COLOR: 255, 0, 0
+              BAR_OUTLINE: False
+              BACKGROUND_COLOR: 0, 0, 0
   DATE:
     INTERVAL: 1
     DAY:

--- a/res/themes/bash-dark-green-gpu/theme.yaml
+++ b/res/themes/bash-dark-green-gpu/theme.yaml
@@ -154,56 +154,58 @@ STATS:
         BACKGROUND_IMAGE: background.png
   DISK:
     INTERVAL: 10
-    USED:
-      GRAPH:
-        SHOW: True
-        X: 33
-        Y: 455
-        WIDTH: 98
-        HEIGHT: 13
-        MIN_VALUE: 0
-        MAX_VALUE: 100
-        BAR_COLOR: 53, 191, 92
-        BAR_OUTLINE: False
-        BACKGROUND_COLOR: 0, 0, 0
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 144
-        Y: 418
-        FONT: roboto-mono/RobotoMono-Regular.ttf
-        FONT_SIZE: 12
-        FONT_COLOR: 53, 191, 92
-        BACKGROUND_IMAGE: background.png
-      PERCENT_TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 46
-        Y: 410
-        FONT: roboto-mono/RobotoMono-Regular.ttf
-        FONT_SIZE: 22
-        FONT_COLOR: 53, 191, 92
-        BACKGROUND_IMAGE: background.png
-    TOTAL:
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 229
-        Y: 418
-        FONT: roboto-mono/RobotoMono-Regular.ttf
-        FONT_SIZE: 12
-        FONT_COLOR: 53, 191, 92
-        BACKGROUND_IMAGE: background.png
-    FREE:
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 144
-        Y: 459
-        FONT: roboto-mono/RobotoMono-Regular.ttf
-        FONT_SIZE: 12
-        FONT_COLOR: 53, 191, 92
-        BACKGROUND_IMAGE: background.png
+    MOUNTS:
+      - "/":
+          USED:
+            GRAPH:
+              SHOW: True
+              X: 33
+              Y: 455
+              WIDTH: 98
+              HEIGHT: 13
+              MIN_VALUE: 0
+              MAX_VALUE: 100
+              BAR_COLOR: 53, 191, 92
+              BAR_OUTLINE: False
+              BACKGROUND_COLOR: 0, 0, 0
+            TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 144
+              Y: 418
+              FONT: roboto-mono/RobotoMono-Regular.ttf
+              FONT_SIZE: 12
+              FONT_COLOR: 53, 191, 92
+              BACKGROUND_IMAGE: background.png
+            PERCENT_TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 46
+              Y: 410
+              FONT: roboto-mono/RobotoMono-Regular.ttf
+              FONT_SIZE: 22
+              FONT_COLOR: 53, 191, 92
+              BACKGROUND_IMAGE: background.png
+          TOTAL:
+            TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 229
+              Y: 418
+              FONT: roboto-mono/RobotoMono-Regular.ttf
+              FONT_SIZE: 12
+              FONT_COLOR: 53, 191, 92
+              BACKGROUND_IMAGE: background.png
+          FREE:
+            TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 144
+              Y: 459
+              FONT: roboto-mono/RobotoMono-Regular.ttf
+              FONT_SIZE: 12
+              FONT_COLOR: 53, 191, 92
+              BACKGROUND_IMAGE: background.png
   NET:
     INTERVAL: 1
     WLO:

--- a/res/themes/bash-dark-green/theme.yaml
+++ b/res/themes/bash-dark-green/theme.yaml
@@ -100,56 +100,58 @@ STATS:
         BACKGROUND_IMAGE: background.png
   DISK:
     INTERVAL: 10
-    USED:
-      GRAPH:
-        SHOW: True
-        X: 33
-        Y: 455
-        WIDTH: 98
-        HEIGHT: 13
-        MIN_VALUE: 0
-        MAX_VALUE: 100
-        BAR_COLOR: 53, 191, 92
-        BAR_OUTLINE: False
-        BACKGROUND_COLOR: 0, 0, 0
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 124
-        Y: 394
-        FONT: roboto-mono/RobotoMono-Regular.ttf
-        FONT_SIZE: 14
-        FONT_COLOR: 53, 191, 92
-        BACKGROUND_IMAGE: background.png
-      PERCENT_TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 46
-        Y: 409
-        FONT: roboto-mono/RobotoMono-Regular.ttf
-        FONT_SIZE: 22
-        FONT_COLOR: 53, 191, 92
-        BACKGROUND_IMAGE: background.png
-    TOTAL:
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 227
-        Y: 394
-        FONT: roboto-mono/RobotoMono-Regular.ttf
-        FONT_SIZE: 14
-        FONT_COLOR: 53, 191, 92
-        BACKGROUND_IMAGE: background.png
-    FREE:
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 124
-        Y: 443
-        FONT: roboto-mono/RobotoMono-Regular.ttf
-        FONT_SIZE: 14
-        FONT_COLOR: 53, 191, 92
-        BACKGROUND_IMAGE: background.png
+    MOUNTS:
+      - "/":
+          USED:
+            GRAPH:
+              SHOW: True
+              X: 33
+              Y: 455
+              WIDTH: 98
+              HEIGHT: 13
+              MIN_VALUE: 0
+              MAX_VALUE: 100
+              BAR_COLOR: 53, 191, 92
+              BAR_OUTLINE: False
+              BACKGROUND_COLOR: 0, 0, 0
+            TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 124
+              Y: 394
+              FONT: roboto-mono/RobotoMono-Regular.ttf
+              FONT_SIZE: 14
+              FONT_COLOR: 53, 191, 92
+              BACKGROUND_IMAGE: background.png
+            PERCENT_TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 46
+              Y: 409
+              FONT: roboto-mono/RobotoMono-Regular.ttf
+              FONT_SIZE: 22
+              FONT_COLOR: 53, 191, 92
+              BACKGROUND_IMAGE: background.png
+          TOTAL:
+            TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 227
+              Y: 394
+              FONT: roboto-mono/RobotoMono-Regular.ttf
+              FONT_SIZE: 14
+              FONT_COLOR: 53, 191, 92
+              BACKGROUND_IMAGE: background.png
+          FREE:
+            TEXT:
+              SHOW: True
+              SHOW_UNIT: True
+              X: 124
+              Y: 443
+              FONT: roboto-mono/RobotoMono-Regular.ttf
+              FONT_SIZE: 14
+              FONT_COLOR: 53, 191, 92
+              BACKGROUND_IMAGE: background.png
   NET:
     INTERVAL: 1
     WLO:

--- a/res/themes/default.yaml
+++ b/res/themes/default.yaml
@@ -63,23 +63,6 @@ STATS:
         SHOW_UNIT: False
   DISK:
     INTERVAL: 10
-    USED:
-      GRAPH:
-        SHOW: False
-      TEXT:
-        SHOW: False
-        SHOW_UNIT: False
-      PERCENT_TEXT:
-        SHOW: False
-        SHOW_UNIT: False
-    TOTAL:
-      TEXT:
-        SHOW: False
-        SHOW_UNIT: False
-    FREE:
-      TEXT:
-        SHOW: False
-        SHOW_UNIT: False
   NET:
     INTERVAL: 1
     WLO:

--- a/res/themes/default_disk.yaml
+++ b/res/themes/default_disk.yaml
@@ -1,0 +1,19 @@
+# This file is used to add mandatory sections to a theme file in case they are missing
+# This is not a theme! Do not use this file to create a new theme, as a lot of content is missing: use theme_example.yaml
+USED:
+  GRAPH:
+    SHOW: False
+  TEXT:
+    SHOW: False
+    SHOW_UNIT: False
+  PERCENT_TEXT:
+    SHOW: False
+    SHOW_UNIT: False
+TOTAL:
+  TEXT:
+    SHOW: False
+    SHOW_UNIT: False
+FREE:
+  TEXT:
+    SHOW: False
+    SHOW_UNIT: False

--- a/res/themes/theme_example.yaml
+++ b/res/themes/theme_example.yaml
@@ -268,61 +268,63 @@ STATS:
         BACKGROUND_IMAGE: background.png
   DISK:
     INTERVAL: 10
-    USED:
-      GRAPH:
-        SHOW: False
-        X: 115
-        Y: 357
-        WIDTH: 178
-        HEIGHT: 13
-        MIN_VALUE: 0
-        MAX_VALUE: 100
-        BAR_COLOR: 255, 0, 0
-        BAR_OUTLINE: False
-        # BACKGROUND_COLOR: 0, 0, 0
-        BACKGROUND_IMAGE: background.png
-      TEXT:
-        SHOW: False
-        SHOW_UNIT: True
-        X: 204
-        Y: 405
-        FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
-        FONT_SIZE: 23
-        FONT_COLOR: 255, 255, 255
-        # BACKGROUND_COLOR: 132, 154, 165
-        BACKGROUND_IMAGE: background.png
-      PERCENT_TEXT:
-        SHOW: False
-        SHOW_UNIT: True
-        X: 46
-        Y: 402
-        FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
-        FONT_SIZE: 23
-        FONT_COLOR: 255, 255, 255
-        # BACKGROUND_COLOR: 132, 154, 165
-        BACKGROUND_IMAGE: background.png
-    TOTAL:
-      TEXT:
-        SHOW: False
-        SHOW_UNIT: True
-        X: 204
-        Y: 375
-        FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
-        FONT_SIZE: 23
-        FONT_COLOR: 255, 255, 255
-        # BACKGROUND_COLOR: 132, 154, 165
-        BACKGROUND_IMAGE: background.png
-    FREE:
-      TEXT:
-        SHOW: False
-        SHOW_UNIT: True
-        X: 204
-        Y: 435
-        FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
-        FONT_SIZE: 23
-        FONT_COLOR: 255, 255, 255
-        # BACKGROUND_COLOR: 132, 154, 165
-        BACKGROUND_IMAGE: background.png
+    MOUNTS:
+      - "/":
+          USED:
+            GRAPH:
+              SHOW: False
+              X: 115
+              Y: 357
+              WIDTH: 178
+              HEIGHT: 13
+              MIN_VALUE: 0
+              MAX_VALUE: 100
+              BAR_COLOR: 255, 0, 0
+              BAR_OUTLINE: False
+              # BACKGROUND_COLOR: 0, 0, 0
+              BACKGROUND_IMAGE: background.png
+            TEXT:
+              SHOW: False
+              SHOW_UNIT: True
+              X: 204
+              Y: 405
+              FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
+              FONT_SIZE: 23
+              FONT_COLOR: 255, 255, 255
+              # BACKGROUND_COLOR: 132, 154, 165
+              BACKGROUND_IMAGE: background.png
+            PERCENT_TEXT:
+              SHOW: False
+              SHOW_UNIT: True
+              X: 46
+              Y: 402
+              FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
+              FONT_SIZE: 23
+              FONT_COLOR: 255, 255, 255
+              # BACKGROUND_COLOR: 132, 154, 165
+              BACKGROUND_IMAGE: background.png
+          TOTAL:
+            TEXT:
+              SHOW: False
+              SHOW_UNIT: True
+              X: 204
+              Y: 375
+              FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
+              FONT_SIZE: 23
+              FONT_COLOR: 255, 255, 255
+              # BACKGROUND_COLOR: 132, 154, 165
+              BACKGROUND_IMAGE: background.png
+          FREE:
+            TEXT:
+              SHOW: False
+              SHOW_UNIT: True
+              X: 204
+              Y: 435
+              FONT: jetbrains-mono/JetBrainsMono-Bold.ttf
+              FONT_SIZE: 23
+              FONT_COLOR: 255, 255, 255
+              # BACKGROUND_COLOR: 132, 154, 165
+              BACKGROUND_IMAGE: background.png
   NET:
     INTERVAL: 1
     WLO:


### PR DESCRIPTION
Hi,

I made some modifications to add support for multiple disks/partitions, by adding the possibility to set multiple disks in the stats section of the theme.yaml, each referenced by its mount point (e.g. drive letter on windows).

Unfortunately, it forces changes to the theme.yaml format that breaks compatibility with previous versions.

I changed the sensors disk functions to add a "path" parameter that is used with psutil.disk_usage.
Stats was modified to add the mountpoint from theme.yaml in the disk functions calls. It also checks if the mount points path exists each time the stats() method is called, which for now spams the logs with a warning, maybe this could be handled better, but at least the program wouldn't crash if a disk/partition becomes unavailable or is unmounted.
The config's load_theme function had to be adapted to handle default values for disks via a seperate "default_disk.yaml" file.

All the default themes were modified accordingly, using "/" as mount point, as it was the case so far.
I think that it should work on all platforms, I tested only on windows.

Pay attention to the theme.yaml, for each disk definition there is a necessary double indent,  due to a subtlety of the yaml format.