### PR TITLE
Force restart device on serial error.

### DIFF
--- a/library/lcd/lcd_comm_rev_a.py
+++ b/library/lcd/lcd_comm_rev_a.py
@@ -41,6 +41,8 @@ class LcdCommRevA(LcdComm):
                  update_queue: queue.Queue = None):
         LcdComm.__init__(self, com_port, display_width, display_height, update_queue)
         self.openSerial()
+        self.idVendor = 0x1a86
+        self.idProduct = 0x5722
 
     def __del__(self):
         self.closeSerial()

--- a/library/lcd/lcd_comm_rev_b.py
+++ b/library/lcd/lcd_comm_rev_b.py
@@ -53,6 +53,8 @@ class LcdCommRevB(LcdComm):
                  update_queue: queue.Queue = None):
         LcdComm.__init__(self, com_port, display_width, display_height, update_queue)
         self.openSerial()
+        self.idVendor = 0x1a86
+        self.idProduct = 0x5722
         self.sub_revision = SubRevision.A01  # Run a Hello command to detect correct sub-rev.
 
     def __del__(self):

--- a/library/lcd/lcd_comm_rev_c.py
+++ b/library/lcd/lcd_comm_rev_c.py
@@ -134,6 +134,8 @@ class LcdCommRevC(LcdComm):
                  update_queue: queue.Queue = None):
         LcdComm.__init__(self, com_port, display_width, display_height, update_queue)
         self.openSerial()
+        self.idVendor = 0x1d6b
+        self.idProduct = 0x0106
 
     def __del__(self):
         self.closeSerial()


### PR DESCRIPTION
With this commit, when the devices stops read/write will clean the queue, reset the device with USB Command, and send "SIGTERM" signal to himself, to stop the daemon.
In linux, with "Restart=always" in service file, will restart the service, fixing some read/write problem.

Please, someone can check if in windows its work ? (i think its work !)