### PR TITLE
Add anchor parameter to DisplayText

### DIFF
--- a/library/display.py
+++ b/library/display.py
@@ -139,7 +139,8 @@ class Display:
                     background_color=config.THEME_DATA['static_text'][text].get("BACKGROUND_COLOR", (255, 255, 255)),
                     background_image=_get_full_path(config.THEME_DATA['PATH'],
                                                     config.THEME_DATA['static_text'][text].get("BACKGROUND_IMAGE",
-                                                                                               None))
+                                                                                               None)),
+                    anchor="lt"
                 )
 
 

--- a/library/stats.py
+++ b/library/stats.py
@@ -94,7 +94,8 @@ def display_themed_value(theme_data, value, min_size=0, unit=''):
         font_size=theme_data.get("FONT_SIZE", 10),
         font_color=theme_data.get("FONT_COLOR", (0, 0, 0)),
         background_color=theme_data.get("BACKGROUND_COLOR", (255, 255, 255)),
-        background_image=get_theme_file_path(theme_data.get("BACKGROUND_IMAGE", None))
+        background_image=get_theme_file_path(theme_data.get("BACKGROUND_IMAGE", None)),
+        anchor="lt"
     )
 
 


### PR DESCRIPTION
The anchor parameter is required to easily (and correctly) place text on the drawn image.

See https://pillow.readthedocs.io/en/stable/handbook/text-anchors.html