### PR TITLE
Shut down webserver when closing connection to sim LCD

### DIFF
--- a/library/lcd/lcd_simulated.py
+++ b/library/lcd/lcd_simulated.py
@@ -63,15 +63,19 @@ class LcdSimulated(LcdComm):
         self.orientation = Orientation.PORTRAIT
 
         try:
-            webServer = HTTPServer(("localhost", WEBSERVER_PORT), SimulatedLcdWebServer)
+            self.webServer = HTTPServer(("localhost", WEBSERVER_PORT), SimulatedLcdWebServer)
             logger.debug("To see your simulated screen, open http://%s:%d in a browser" % ("localhost", WEBSERVER_PORT))
-            threading.Thread(target=webServer.serve_forever).start()
+            threading.Thread(target=self.webServer.serve_forever).start()
         except OSError:
             logger.error("Error starting webserver! An instance might already be running on port %d." % WEBSERVER_PORT)
 
     @staticmethod
     def auto_detect_com_port():
         return None
+
+    def closeSerial(self):
+        logger.debug("Shutting down web server")
+        self.webServer.shutdown()
 
     def InitializeComm(self):
         pass


### PR DESCRIPTION
Previously, the web server thread not stopping prevented the whole program (e.g. simple-program.py) from exiting.

Closing the webserver in the closeSerial seems to be the most logical, as we can expect this method to be called already when the program is shutting down (as it's the case in simple-program.py for example)

Maybe updating the wiki page about the simulated LCD to mention the need to call closeSerial to stop the server would be nice too.