### PR TITLE
Optimize rgb565 serialization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Python packages requirements
 Pillow~=9.5.0         # Image generation
 pyserial~=3.5         # Serial linl to communicate with the display
+numpy~=1.19           # Efficient image serialization
 PyYAML~=6.0           # For themes files
 psutil~=5.9.5         # CPU / disk / network metrics
 GPUtil~=1.4.0         # Nvidia GPU

--- a/simple-program.py
+++ b/simple-program.py
@@ -22,6 +22,7 @@
 import os
 import signal
 import sys
+import time
 from datetime import datetime
 
 # Import only the modules for LCD communication
@@ -117,7 +118,11 @@ if __name__ == "__main__":
         background = f"res/backgrounds/{REVISION}/example{size}_landscape.png"
 
     # Display sample picture
+    logger.debug("setting background picture")
+    start = time.perf_counter()
     lcd_comm.DisplayBitmap(background)
+    end = time.perf_counter()
+    logger.debug(f"background picture set (took {end-start:.3f} s)")
 
     # Display sample text
     lcd_comm.DisplayText("Basic text", 50, 100)
@@ -140,6 +145,7 @@ if __name__ == "__main__":
     # Display the current time and some progress bars as fast as possible
     bar_value = 0
     while not stop:
+        start = time.perf_counter()
         lcd_comm.DisplayText(str(datetime.now().time()), 160, 2,
                              font="roboto/Roboto-Bold.ttf",
                              font_size=20,
@@ -184,6 +190,8 @@ if __name__ == "__main__":
                                           background_image=background)
 
         bar_value = (bar_value + 2) % 101
+        end = time.perf_counter()
+        logger.debug(f"refresh done (took {end-start:.3f} s)")
 
     # Close serial connection at exit
     lcd_comm.closeSerial()


### PR DESCRIPTION
For context: I'm trying to drive a rev A display from a (gen 1) Raspberry Pi. On a weak CPU like that, the sample program `simple-program.py` is extremely slow (~30 s to paint the background image) and the CPU usage is very high (constantly ~80 %).

So, I did some profiling and I've seen that the serialization to little-endian RGB565 was the main culprit for CPU usage. Using numpy yields a huge improvement.

I've added some timing debug messages to the `simple-program`, here's before:

```
2023-09-05 23:28:01.624 [DEBUG] background picture set (took 29.658 s)
2023-09-05 23:28:09.804 [DEBUG] refresh done (took 4.121 s)
2023-09-05 23:28:13.989 [DEBUG] refresh done (took 4.178 s)
2023-09-05 23:28:18.138 [DEBUG] refresh done (took 4.142 s)
2023-09-05 23:28:22.278 [DEBUG] refresh done (took 4.134 s)
```

and after:

```
2023-09-05 23:29:01.502 [DEBUG] background picture set (took 6.218 s)
2023-09-05 23:29:03.760 [DEBUG] refresh done (took 1.265 s)
2023-09-05 23:29:04.970 [DEBUG] refresh done (took 1.204 s)
2023-09-05 23:29:06.182 [DEBUG] refresh done (took 1.205 s)
2023-09-05 23:29:07.392 [DEBUG] refresh done (took 1.204 s)
```

Also, the CPU usage goes from ~80% to ~40%.

So, it's still not fast, but a 5x speedup in showing the BG, and >3x speedup in refreshing the info makes it much more useable.

On my desktop with a more powerful CPU, the timings only show a slight improvement (BG paint goes from 1.49s to 1.33s, refresh from 0.22s to 0.19s). However, there's a 2x difference in CPU usage, from ~30% to ~15%.

Sure, there's the downside of adding numpy as a dep, but I think that's not a big problem, lots of things depend on it, the Raspberry Pi OS even comes with it pre-installed.