### PR TITLE
Add FPS meter for LibreHardwareMonitor integration

### DIFF
--- a/library/sensors/sensors.py
+++ b/library/sensors/sensors.py
@@ -58,6 +58,11 @@ class Gpu(ABC):
 
     @staticmethod
     @abstractmethod
+    def fps() -> int:
+        pass
+
+    @staticmethod
+    @abstractmethod
     def is_available() -> bool:
         pass
 

--- a/library/sensors/sensors_python.py
+++ b/library/sensors/sensors_python.py
@@ -113,6 +113,11 @@ class Gpu(sensors.Gpu):
             return math.nan, math.nan, math.nan, math.nan
 
     @staticmethod
+    def fps() -> int:
+        # Not supported by Python libraries
+        return -1
+
+    @staticmethod
     def is_available() -> bool:
         global DETECTED_GPU
         if GpuAmd.is_available():
@@ -163,6 +168,11 @@ class GpuNvidia(sensors.Gpu):
             temperature = math.nan
 
         return load, memory_percentage, memory_used_mb, temperature
+
+    @staticmethod
+    def fps() -> int:
+        # Not supported by Python libraries
+        return -1
 
     @staticmethod
     def is_available() -> bool:
@@ -228,6 +238,11 @@ class GpuAmd(sensors.Gpu):
 
             # Memory absolute (M) and relative (%) usage not supported by pyadl
             return load, math.nan, math.nan, temperature
+
+    @staticmethod
+    def fps() -> int:
+        # Not supported by Python libraries
+        return -1
 
     @staticmethod
     def is_available() -> bool:

--- a/library/sensors/sensors_stub_random.py
+++ b/library/sensors/sensors_stub_random.py
@@ -53,6 +53,10 @@ class Gpu(sensors.Gpu):
         return random.uniform(0, 100), random.uniform(0, 100), random.uniform(300, 16000), random.uniform(30, 90)
 
     @staticmethod
+    def fps() -> int:
+        return random.randint(20, 120)
+
+    @staticmethod
     def is_available() -> bool:
         return True
 

--- a/library/sensors/sensors_stub_static.py
+++ b/library/sensors/sensors_stub_static.py
@@ -34,6 +34,7 @@ DISK_TOTAL_SIZE_GB = 1000
 MEMORY_TOTAL_SIZE_GB = 64
 GPU_MEM_TOTAL_SIZE_GB = 32
 NETWORK_SPEED_BYTES = 1061000000
+GPU_FPS = 120
 
 
 class Cpu(sensors.Cpu):
@@ -63,6 +64,10 @@ class Gpu(sensors.Gpu):
     def stats() -> Tuple[float, float, float, float]:  # load (%) / used mem (%) / used mem (Mb) / temp (°C)
         return PERCENTAGE_SENSOR_VALUE, PERCENTAGE_SENSOR_VALUE, \
             GPU_MEM_TOTAL_SIZE_GB / 100 * PERCENTAGE_SENSOR_VALUE * 1000, TEMPERATURE_SENSOR_VALUE
+
+    @staticmethod
+    def fps() -> int:
+        return GPU_FPS
 
     @staticmethod
     def is_available() -> bool:

--- a/library/stats.py
+++ b/library/stats.py
@@ -223,12 +223,12 @@ class CPU:
         )
 
 
-def display_gpu_stats(load, memory_percentage, memory_used_mb, temperature):
+def display_gpu_stats(load, memory_percentage, memory_used_mb, temperature, fps):
     theme_gpu_data = config.THEME_DATA['STATS']['GPU']
+
     gpu_percent_graph_data = theme_gpu_data['PERCENTAGE']['GRAPH']
     gpu_percent_radial_data = theme_gpu_data['PERCENTAGE']['RADIAL']
     gpu_percent_text_data = theme_gpu_data['PERCENTAGE']['TEXT']
-
     if math.isnan(load):
         load = 0
         if gpu_percent_graph_data['SHOW'] or gpu_percent_text_data['SHOW'] or gpu_percent_radial_data['SHOW']:
@@ -259,6 +259,12 @@ def display_gpu_stats(load, memory_percentage, memory_used_mb, temperature):
         if gpu_temp_text_data['SHOW']:
             logger.warning("Your GPU temperature is not supported yet")
             gpu_temp_text_data['SHOW'] = False
+
+    gpu_fps_text_data = theme_gpu_data['FPS']['TEXT']
+    if fps < 0:
+        if gpu_fps_text_data['SHOW']:
+            logger.warning("Your GPU FPS is not supported yet")
+            gpu_fps_text_data['SHOW'] = False
 
     # logger.debug(f"GPU Load: {load}")
     display_themed_progress_bar(gpu_percent_graph_data, load)
@@ -299,12 +305,20 @@ def display_gpu_stats(load, memory_percentage, memory_used_mb, temperature):
         unit="°C"
     )
 
+    display_themed_value(
+        theme_data=gpu_fps_text_data,
+        value=int(fps),
+        min_size=4,
+        unit=" FPS"
+    )
+
 
 class Gpu:
     @staticmethod
     def stats():
         load, memory_percentage, memory_used_mb, temperature = sensors.Gpu.stats()
-        display_gpu_stats(load, memory_percentage, memory_used_mb, temperature)
+        fps = sensors.Gpu.fps()
+        display_gpu_stats(load, memory_percentage, memory_used_mb, temperature, fps)
 
     @staticmethod
     def is_available():

--- a/res/themes/default.yaml
+++ b/res/themes/default.yaml
@@ -50,6 +50,10 @@ STATS:
       TEXT:
         SHOW: False
         SHOW_UNIT: False
+    FPS:
+      TEXT:
+        SHOW: False
+        SHOW_UNIT: False
   MEMORY:
     INTERVAL: 5
     SWAP:

--- a/res/themes/theme_example.yaml
+++ b/res/themes/theme_example.yaml
@@ -273,6 +273,17 @@ STATS:
         FONT_COLOR: 200, 200, 200
         # BACKGROUND_COLOR: 50, 50, 50
         BACKGROUND_IMAGE: background.png
+    FPS:
+      TEXT:
+        SHOW: False
+        SHOW_UNIT: True
+        X: 115
+        Y: 231
+        FONT: roboto/Roboto-Bold.ttf
+        FONT_SIZE: 13
+        FONT_COLOR: 200, 200, 200
+        # BACKGROUND_COLOR: 50, 50, 50
+        BACKGROUND_IMAGE: background.png
   MEMORY:
     # In seconds. Longer intervals cause this to refresh more slowly.
     # Setting to lower values will display near real time data,


### PR DESCRIPTION
This allows to show the FPS framerate on the screen.
Note: it is available only on Windows platforms for LibreHardwareMonitor HW integration, and works only for AMD GPUs