### PR TITLE
Use sys.executable to launch python scripts

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -364,14 +364,14 @@ class TuringConfigWindow:
         self.load_theme_preview()
 
     def on_theme_editor_click(self):
-        subprocess.Popen(os.path.join(os.getcwd(), "theme-editor.py") + " \"" + self.theme_cb.get() + "\"", shell=True)
+        subprocess.Popen([sys.executable, os.path.join(os.getcwd(), "theme-editor.py"), self.theme_cb.get()])
 
     def on_save_click(self):
         self.save_config_values()
 
     def on_saverun_click(self):
         self.save_config_values()
-        subprocess.Popen(os.path.join(os.getcwd(), "main.py"), shell=True)
+        subprocess.Popen([sys.executable, os.path.join(os.getcwd(), "main.py")])
         self.window.destroy()
 
     def on_brightness_change(self, e=None):

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
 
     def on_configure_tray(tray_icon, item):
         logger.info("Configure from tray icon")
-        subprocess.Popen(os.path.join(os.getcwd(), "configure.py"), shell=True)
+        subprocess.Popen([sys.executable, os.path.join(os.getcwd(), "configure.py")])
         clean_stop(tray_icon)
 
 


### PR DESCRIPTION
So that scripts like `main.py` is launched by same python executable used by `configure.py`