### PR TITLE
SystemUptime

### DIFF
--- a/library/scheduler.py
+++ b/library/scheduler.py
@@ -153,6 +153,11 @@ def DateStats():
     # logger.debug("Refresh date stats")
     stats.Date.stats()
 
+@async_job("SystemUptime_Stats")
+@schedule(timedelta(seconds=config.THEME_DATA['STATS']['UPTIME'].get("INTERVAL", None)).total_seconds())
+def SystemUptimeStats():
+    # logger.debug("Refresh system uptime stats")
+    stats.SystemUptime.stats()
 
 @async_job("Custom_Stats")
 @schedule(timedelta(seconds=config.THEME_DATA['STATS']['CUSTOM'].get("INTERVAL", None)).total_seconds())

--- a/library/stats.py
+++ b/library/stats.py
@@ -34,7 +34,7 @@ from psutil._common import bytes2human
 import library.config as config
 from library.display import display
 from library.log import logger
-
+from uptime import uptime
 DEFAULT_HISTORY_SIZE = 10
 
 ETH_CARD = config.CONFIG_DATA["config"]["ETH"]
@@ -721,6 +721,36 @@ class Date:
             theme_data=hour_theme_data,
             value=f"{babel.dates.format_time(date_now, format=time_format, locale=lc_time)}"
         )
+
+
+class SystemUptime:
+    @staticmethod
+    def stats():
+        if HW_SENSORS == "STATIC":
+            # For static sensors, use predefined uptime
+            uptimesec = "4294036"
+            uptimeformatted = "49 days, 16:47:16"
+        else:
+            uptimesec = int(uptime())
+            uptimeformatted = str(datetime.timedelta(seconds = uptimesec))
+
+        systemuptime_theme_data = config.THEME_DATA['STATS']['UPTIME']
+        
+        systemuptime_sec_theme_data = systemuptime_theme_data['SECONDS']['TEXT']
+        systemuptime_sec_format = systemuptime_sec_theme_data.get("FORMAT", 'medium')
+        if systemuptime_sec_theme_data and systemuptime_sec_theme_data['SHOW']:
+            display_themed_value(
+                theme_data = systemuptime_sec_theme_data,
+                value= uptimesec
+            )
+            
+        systemuptime_withdays_theme_data = systemuptime_theme_data['WITHDAYS']['TEXT']
+        systemuptime_formatted_format = systemuptime_withdays_theme_data.get("FORMAT", 'medium')
+        if systemuptime_withdays_theme_data and systemuptime_withdays_theme_data['SHOW']:
+            display_themed_value(
+                theme_data = systemuptime_withdays_theme_data,
+                value= uptimeformatted
+            )
 
 
 class Custom:

--- a/main.py
+++ b/main.py
@@ -208,6 +208,7 @@ if __name__ == "__main__":
     scheduler.DiskStats()
     scheduler.NetStats()
     scheduler.DateStats()
+    scheduler.SystemUptimeStats()
     scheduler.CustomStats()
     scheduler.QueueHandler()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pystray~=0.19.5       # Tray icon (all OS)
 babel~=2.14.0         # Date/time formatting
 ruamel.yaml~=0.18.6  # For configuration editor
 sv-ttk~=2.6.0         # Tk Sun Valley theme for configuration editor
+uptime~=3.0.1         # For System Uptime 
 
 # Efficient image serialization
 numpy~=1.24.4; python_version < "3.9"   # For Python 3.8 max.

--- a/res/themes/default.yaml
+++ b/res/themes/default.yaml
@@ -206,5 +206,13 @@ STATS:
     HOUR:
       TEXT:
         SHOW: False
+  UPTIME:
+    INTERVAL: 100
+    SECONDS:
+      TEXT:
+        SHOW: False
+    WITHDAYS:
+      TEXT:
+        SHOW: False
   CUSTOM:
     INTERVAL: 100

--- a/theme-editor.py
+++ b/theme-editor.py
@@ -111,6 +111,7 @@ def refresh_theme():
     stats.Disk.stats()
     stats.Net.stats()
     stats.Date.stats()
+    stats.SystemUptime.stats()
     stats.Custom.stats()
 
 


### PR DESCRIPTION
Im proud to say I've done my first Steps in Python 🥳

Added a SystemUptime Routine that gets the runtime of the System like wished in Incident #448.
There are two new values you can get.
['STATS']['UPTIME']['SECONDS']['TEXT'] --> uptime from the system in seconds
['STATS']['UPTIME']['WITHDAYS']['TEXT'] --> formatted uptime from the system in the format "49 days, 16:47:16"

Tested it on Windows 11, Debian 12 and virtual Display via theme editor.

![2024-03-29 15_52_38-Turing SysMon Theme Editor](https://github.com/mathoudebine/turing-smart-screen-python/assets/32042518/eed89c22-8c05-4e12-aade-4b44d0cbb0a1)
