### PR TITLE
Convert `amd_gpu.query_load()` value to a percentage

### DIFF
--- a/library/sensors/sensors_python.py
+++ b/library/sensors/sensors_python.py
@@ -331,7 +331,7 @@ class GpuAmd(sensors.Gpu):
                 memory_percentage = math.nan
 
             try:
-                load = amd_gpu.query_load()
+                load = amd_gpu.query_load() * 100
             except:
                 load = math.nan
 


### PR DESCRIPTION
My RX 7800XT usage always showed 0% load. After this change, it shows a more believable figure.

[The docstring](https://github.com/mark9064/pyamdgpuinfo/blob/master/pyamdgpuinfo/_pyamdgpuinfo.pyx#L562-L571) in pyamdgpuinfo specifies the return value is a float between 0 and 1.