### PR TITLE
Update numpy to v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,8 +129,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# PyCharm
+# Editors / IDEs
 .idea/
+.vscode/
 
 # Git mergetool backup
 *.orig

--- a/library/lcd/lcd_comm_rev_a.py
+++ b/library/lcd/lcd_comm_rev_a.py
@@ -196,7 +196,7 @@ class LcdCommRevA(LcdComm):
         rgb565 = (r << 11) | (g << 5) | b
 
         # serialize to little-endian
-        return rgb565.newbyteorder('<').tobytes()
+        return rgb565.astype('<u2').tobytes()
 
     def DisplayPILImage(
             self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ uptime~=3.0.1          # For System Uptime
 
 # Efficient image serialization
 numpy~=1.24.4; python_version < "3.9"   # For Python 3.8 max.
-numpy~=1.26.4; python_version >= "3.9"  # For Python 3.9+
+numpy~=2.0.0; python_version == "3.9"  # For Python 3.9, only numpy 2.0.x is supported as 2.1 only supports Python >=3.10
+numpy~=2.0; python_version >= "3.10"  # For Python >=3.10, any numpy 2.x is fine
 
 # For Nvidia GPU on all platforms
 GPUtil~=1.4.0; python_version < "3.12"


### PR DESCRIPTION
Using `astype("<u2")` should work will all numpy versions... It's also the correct way to achieve the desired serialization, as `newbyteorder` wasn't actually doing anything to the byte data :sweat_smile: 