### PR TITLE
[WIP] Added multi-disk support

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -38,7 +38,10 @@ MAIN_DIRECTORY = Path(__file__).parent.parent.resolve()
 FONTS_DIR = str(MAIN_DIRECTORY / "res" / "fonts") + "/"
 CONFIG_DATA = load_yaml(MAIN_DIRECTORY / "config.yaml")
 THEME_DEFAULT = load_yaml(MAIN_DIRECTORY / "res/themes/default.yaml")
+THEME_DISK_DEFAULT = load_yaml("res/themes/default_disk.yaml")
 THEME_DATA = None
+
+
 
 
 def copy_default(default, theme):
@@ -66,6 +69,10 @@ def load_theme():
 
     copy_default(THEME_DEFAULT, THEME_DATA)
 
+    if THEME_DATA['STATS']['DISK'].get("MOUNTS", False):
+        for mount in THEME_DATA['STATS']['DISK']['MOUNTS']:
+            mountpoint = [k for k, v in mount.items()][0]
+            copy_default(THEME_DISK_DEFAULT, mount[mountpoint])
 
 def check_theme_compatible(display_size: str):
     global THEME_DATA

--- a/library/sensors/sensors.py
+++ b/library/sensors/sensors.py
@@ -103,17 +103,17 @@ class Memory(ABC):
 class Disk(ABC):
     @staticmethod
     @abstractmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path) -> float:
         pass
 
     @staticmethod
     @abstractmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path) -> int:  # In bytes
         pass
 
     @staticmethod
     @abstractmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path) -> int:  # In bytes
         pass
 
 

--- a/library/sensors/sensors_python.py
+++ b/library/sensors/sensors_python.py
@@ -443,23 +443,23 @@ class Memory(sensors.Memory):
 
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path) -> float:
         try:
-            return psutil.disk_usage("/").percent
+            return psutil.disk_usage(path).percent
         except:
             return math.nan
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path) -> int:  # In bytes
         try:
-            return psutil.disk_usage("/").used
+            return psutil.disk_usage(path).used
         except:
             return -1
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path) -> int:  # In bytes
         try:
-            return psutil.disk_usage("/").free
+            return psutil.disk_usage(path).free
         except:
             return -1
 

--- a/library/sensors/sensors_stub_random.py
+++ b/library/sensors/sensors_stub_random.py
@@ -91,15 +91,15 @@ class Memory(sensors.Memory):
 
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path) -> float:
         return random.uniform(0, 100)
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path) -> int:  # In bytes
         return random.randint(1000000000, 2000000000000)
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path) -> int:  # In bytes
         return random.randint(1000000000, 2000000000000)
 
 

--- a/library/stats.py
+++ b/library/stats.py
@@ -645,37 +645,46 @@ class Disk:
 
     @classmethod
     def stats(cls):
-        used = sensors.Disk.disk_used()
-        free = sensors.Disk.disk_free()
+        if 'MOUNTS' not in config.THEME_DATA['STATS']['DISK']:
+            print("Doing mounts")
+            mountpoints = [ config.THEME_DATA['STATS']['DISK'] ]
+        else:
+            mountpoints = config.THEME_DATA['STATS']['DISK']['MOUNTS']
 
-        disk_theme_data = config.THEME_DATA['STATS']['DISK']
+        for mount in mountpoints:
+            mountpoint = [k for k, v in mount.items()][0]
+            disk_theme_data = mount[mountpoint]
+            if not os.path.exists(mountpoint):
+                logger.warning('Invalid mount point in config: "%s"' % mountpoint)
+            else:
+                used = sensors.Disk.disk_used(mountpoint)
+                free = sensors.Disk.disk_free(mountpoint)
 
-        disk_usage_percent = sensors.Disk.disk_usage_percent()
-        save_last_value(disk_usage_percent, cls.last_values_disk_usage,
-                        disk_theme_data['USED']['LINE_GRAPH'].get("HISTORY_SIZE", DEFAULT_HISTORY_SIZE))
-        display_themed_progress_bar(disk_theme_data['USED']['GRAPH'], disk_usage_percent)
-        display_themed_percent_radial_bar(disk_theme_data['USED']['RADIAL'], disk_usage_percent)
-        display_themed_percent_value(disk_theme_data['USED']['PERCENT_TEXT'], disk_usage_percent)
-        display_themed_line_graph(disk_theme_data['USED']['LINE_GRAPH'], cls.last_values_disk_usage)
+            disk_usage_percent = sensors.Disk.disk_usage_percent(mountpoint)
+            save_last_value(disk_usage_percent, cls.last_values_disk_usage, DEFAULT_HISTORY_SIZE)
+            #display_themed_progress_bar(disk_theme_data['USED']['GRAPH'], disk_usage_percent)
+            #display_themed_percent_radial_bar(disk_theme_data['USED']['RADIAL'], disk_usage_percent)
+            display_themed_percent_value(disk_theme_data['USED']['PERCENT_TEXT'], disk_usage_percent)
+            #display_themed_line_graph(disk_theme_data['USED']['LINE_GRAPH'], cls.last_values_disk_usage)
 
-        display_themed_value(
-            theme_data=disk_theme_data['USED']['TEXT'],
-            value=int(used / 1000000000),
-            min_size=5,
-            unit=" G"
-        )
-        display_themed_value(
-            theme_data=disk_theme_data['TOTAL']['TEXT'],
-            value=int((free + used) / 1000000000),
-            min_size=5,
-            unit=" G"
-        )
-        display_themed_value(
-            theme_data=disk_theme_data['FREE']['TEXT'],
-            value=int(free / 1000000000),
-            min_size=5,
-            unit=" G"
-        )
+            display_themed_value(
+                theme_data=disk_theme_data['USED']['TEXT'],
+                value=int(used / 1000000000),
+                min_size=5,
+                unit=" G"
+            )
+            display_themed_value(
+                theme_data=disk_theme_data['TOTAL']['TEXT'],
+                value=int((free + used) / 1000000000),
+                min_size=5,
+                unit=" G"
+            )
+            display_themed_value(
+                theme_data=disk_theme_data['FREE']['TEXT'],
+                value=int(free / 1000000000),
+                min_size=5,
+                unit=" G"
+            )
 
 
 class Net:

--- a/res/themes/CustomDataExample/theme.yaml
+++ b/res/themes/CustomDataExample/theme.yaml
@@ -16,6 +16,69 @@ static_images:
     HEIGHT: 320
 
 STATS:
+  DISK:
+    INTERVAL: 10
+    MOUNTS:
+    - '/':
+        USED:
+          TEXT:
+            SHOW: True
+            SHOW_UNIT: True
+            X: 155
+            Y: 338
+            FONT: generale-mono/GeneraleMonoA.ttf
+            FONT_SIZE: 26
+            FONT_COLOR: 2, 216, 243
+            BACKGROUND_IMAGE: background.png
+          PERCENT_TEXT:
+            SHOW: True
+            SHOW_UNIT: True
+            X: 170
+            Y: 430
+            FONT: generale-mono/GeneraleMonoA.ttf
+            FONT_SIZE: 30
+            FONT_COLOR: 2, 216, 243
+            BACKGROUND_IMAGE: background.png
+        FREE:
+          TEXT:
+            SHOW: True
+            SHOW_UNIT: True
+            X: 155
+            Y: 383
+            FONT: generale-mono/GeneraleMonoA.ttf
+            FONT_SIZE: 26
+            FONT_COLOR: 2, 216, 243
+            BACKGROUND_IMAGE: background.png
+    - '/boot/efi':
+        USED:
+          TEXT:
+            SHOW: True
+            SHOW_UNIT: True
+            X: 155
+            Y: 338
+            FONT: generale-mono/GeneraleMonoA.ttf
+            FONT_SIZE: 26
+            FONT_COLOR: 2, 216, 243
+            BACKGROUND_IMAGE: background.png
+          PERCENT_TEXT:
+            SHOW: True
+            SHOW_UNIT: True
+            X: 170
+            Y: 430
+            FONT: generale-mono/GeneraleMonoA.ttf
+            FONT_SIZE: 30
+            FONT_COLOR: 2, 216, 243
+            BACKGROUND_IMAGE: background.png
+        FREE:
+          TEXT:
+            SHOW: True
+            SHOW_UNIT: True
+            X: 155
+            Y: 383
+            FONT: generale-mono/GeneraleMonoA.ttf
+            FONT_SIZE: 26
+            FONT_COLOR: 2, 216, 243
+            BACKGROUND_IMAGE: background.png
   DATE:
     INTERVAL: 1
     HOUR:

--- a/res/themes/Cyberpunk/theme.yaml
+++ b/res/themes/Cyberpunk/theme.yaml
@@ -185,35 +185,37 @@ STATS:
         BACKGROUND_IMAGE: background.png
   DISK:
     INTERVAL: 10
-    USED:
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 155
-        Y: 338
-        FONT: generale-mono/GeneraleMonoA.ttf
-        FONT_SIZE: 26
-        FONT_COLOR: 2, 216, 243
-        BACKGROUND_IMAGE: background.png
-      PERCENT_TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 170
-        Y: 430
-        FONT: generale-mono/GeneraleMonoA.ttf
-        FONT_SIZE: 30
-        FONT_COLOR: 2, 216, 243
-        BACKGROUND_IMAGE: background.png
-    FREE:
-      TEXT:
-        SHOW: True
-        SHOW_UNIT: True
-        X: 155
-        Y: 383
-        FONT: generale-mono/GeneraleMonoA.ttf
-        FONT_SIZE: 26
-        FONT_COLOR: 2, 216, 243
-        BACKGROUND_IMAGE: background.png
+    MOUNTS:
+    - '/':
+        USED:
+          TEXT:
+            SHOW: True
+            SHOW_UNIT: True
+            X: 155
+            Y: 338
+            FONT: generale-mono/GeneraleMonoA.ttf
+            FONT_SIZE: 26
+            FONT_COLOR: 2, 216, 243
+            BACKGROUND_IMAGE: background.png
+          PERCENT_TEXT:
+            SHOW: True
+            SHOW_UNIT: True
+            X: 170
+            Y: 320
+            FONT: generale-mono/GeneraleMonoA.ttf
+            FONT_SIZE: 30
+            FONT_COLOR: 2, 216, 243
+            BACKGROUND_IMAGE: background.png
+        FREE:
+          TEXT:
+            SHOW: True
+            SHOW_UNIT: True
+            X: 155
+            Y: 383
+            FONT: generale-mono/GeneraleMonoA.ttf
+            FONT_SIZE: 26
+            FONT_COLOR: 2, 216, 243
+            BACKGROUND_IMAGE: background.png
   DATE:
     INTERVAL: 1
     DAY:

--- a/res/themes/default_disk.yaml
+++ b/res/themes/default_disk.yaml
@@ -1,0 +1,19 @@
+# This file is used to add mandatory sections to a theme file in case they are missing
+# This is not a theme! Do not use this file to create a new theme, as a lot of content is missing: use theme_example.yaml
+USED:
+  GRAPH:
+    SHOW: False
+  TEXT:
+    SHOW: False
+    SHOW_UNIT: False
+  PERCENT_TEXT:
+    SHOW: False
+    SHOW_UNIT: False
+TOTAL:
+  TEXT:
+    SHOW: False
+    SHOW_UNIT: False
+FREE:
+  TEXT:
+    SHOW: False
+    SHOW_UNIT: False


### PR DESCRIPTION
This is to continue upon @smandon's work on #224 

Since there have been a lot of changes. I'm waiting for this to be implemented before I can buy and use the turing smart screen.

I can add more themes configuration and also modifications that are needed if this is something the maintainers are interesting in merging.

I need help with designing the UI that can actually display the multiple disks. For now all this is good for is changing the disk whose stats are displayed instead of the default root. Other entries are ignored.

If you have any questions or requests feel free to ask.