### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -26,10 +26,10 @@ Add screenshots or photos/mockups of the rendering on the Turing screen to help 
 You can drag and drop photos here to add them to the description.
 
 **Environment:**  
- - Revision of this project [e.g. 1.1.1, `main` branch, specific commit]
+ - Revision of this project [e.g. 3.7.0, `main` branch, specific commit]
  - OS with version [e.g. Windows 11, Ubuntu 22.04]
- - Python version [e.g. Python 3.8]
- - Hardware [e.g. Intel CPU, Nvidia GPU, Raspberry Pi 3 B+ ...]
+ - Python version [e.g. Python 3.13]
+ - Hardware [e.g. Intel CPU, Nvidia GPU, Raspberry Pi 5 ...]
 
 **Additional context**  
 Add any other context or screenshots about the feature request here.

--- a/.github/workflows/simple-program-linux.yml
+++ b/.github/workflows/simple-program-linux.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/simple-program-macos.yml
+++ b/.github/workflows/simple-program-macos.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/simple-program-windows.yml
+++ b/.github/workflows/simple-program-windows.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/system-monitor-linux.yml
+++ b/.github/workflows/system-monitor-linux.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         theme: [ "3.5inchTheme2" ]
 
     steps:

--- a/.github/workflows/system-monitor-macos.yml
+++ b/.github/workflows/system-monitor-macos.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         theme: [ "3.5inchTheme2" ]
 
     steps:

--- a/.github/workflows/system-monitor-windows.yml
+++ b/.github/workflows/system-monitor-windows.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         theme: [ "3.5inchTheme2" ]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This project is an open-source alternative software, NOT the original software p
 * for other smart screens, contact your reseller
 ---
 
-![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black) ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white) ![macOS](https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=apple&logoColor=white) ![Raspberry Pi](https://img.shields.io/badge/Raspberry%20Pi-A22846?style=for-the-badge&logo=Raspberry%20Pi&logoColor=white) ![Python](https://img.shields.io/badge/Python-3.8/3.13-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54) [![Licence](https://img.shields.io/github/license/mathoudebine/turing-smart-screen-python?style=for-the-badge)](./LICENSE)
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black) ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white) ![macOS](https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=apple&logoColor=white) ![Raspberry Pi](https://img.shields.io/badge/Raspberry%20Pi-A22846?style=for-the-badge&logo=Raspberry%20Pi&logoColor=white) ![Python](https://img.shields.io/badge/Python-3.9/3.13-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54) [![Licence](https://img.shields.io/github/license/mathoudebine/turing-smart-screen-python?style=for-the-badge)](./LICENSE)
   
 
 A Python system monitor program and an abstraction library for **small IPS USB-C (UART) displays.**    
 
-Supported operating systems : macOS, Windows, Linux (incl. Raspberry Pi), basically all OS that support Python 3.8+  
+Supported operating systems : macOS, Windows, Linux (incl. Raspberry Pi), basically all OS that support Python 3.9+  
 
 ### Supported smart screens models:
 

--- a/configure.py
+++ b/configure.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 import webbrowser
 
-MIN_PYTHON = (3, 8)
+MIN_PYTHON = (3, 9)
 if sys.version_info < MIN_PYTHON:
     print("[ERROR] Python %s.%s or later is required." % MIN_PYTHON)
     try:

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ import glob
 import os
 import sys
 
-MIN_PYTHON = (3, 8)
+MIN_PYTHON = (3, 9)
 if sys.version_info < MIN_PYTHON:
     print("[ERROR] Python %s.%s or later is required." % MIN_PYTHON)
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,14 +11,10 @@ uptime~=3.0.1          # For System Uptime
 requests~=2.32.3       # HTTP library
 ping3~=4.0.8           # ICMP ping implementation using raw socket
 pyinstaller~=6.11.1    # bundles a Python application and all its dependencies into a single package
-
-# Image generation
-Pillow~=10.4.0; python_version < "3.9"    # For Python 3.8 max.
-Pillow~=11.1.0; python_version >= "3.9"  # For Python >=3.9
+Pillow~=11.1.0         # Image generation
 
 # Efficient image serialization
-numpy~=1.24.4; python_version < "3.9"   # For Python 3.8 max.
-numpy~=2.0.2; python_version == "3.9"  # For Python 3.9, only numpy 2.0.x is supported as 2.1 only supports Python >=3.10
+numpy~=2.0.2; python_version < "3.10"  # For Python 3.9, only numpy 2.0.x is supported as 2.1 only supports Python >=3.10
 numpy~=2.2.1; python_version >= "3.10"  # For Python >=3.10, any numpy 2.x is fine
 
 # For Nvidia GPU on all platforms


### PR DESCRIPTION
Python 3.8 is now deprecated, and modules are starting to drop support for it