### PR TITLE
Add config option for reset workaround rev.A

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,15 +1,14 @@
----
 config:
   # Configuration values to set up basic communication
   # Set your COM port e.g. COM3 for Windows, /dev/ttyACM0 for Linux...
   # Use AUTO for COM port auto-discovery (may not work on every setup)
   # COM_PORT: "/dev/ttyACM0"
   # COM_PORT: "COM3"
-  COM_PORT: "AUTO"
+  COM_PORT: COM1
 
   # Theme to use (located in res/themes)
   # Use the name of the folder as value
-  THEME: 3.5inchTheme2
+  THEME: Cyberpunk-net
 
   # Hardware sensors reading
   # Choose the appropriate method for reading your hardware sensors:
@@ -17,14 +16,14 @@ config:
   # - LHM            use LibreHardwareMonitor library to read hardware sensors (Windows only - NEEDS ADMIN RIGHTS)
   # - STUB / STATIC  use random/static data instead of real hardware sensors
   # - AUTO           use the best method based on your OS: Windows OS will use LHM, other OS will use Python libraries
-  HW_SENSORS: AUTO
+  HW_SENSORS: PYTHON
 
   # Network interfaces
   # Linux/MacOS interfaces are named "eth0", "wlan0", "wlp1s0", "enp2s0"...
   # For Windows use the interfaces pretty name: "Ethernet 2", "Wi-Fi", ...
   # Leave the fields empty if the card does not exist on your setup
-  ETH: "" # Ethernet Card
-  WLO: "" # Wi-Fi Card
+  ETH: Ethernet # Ethernet Card
+  WLO: Wi-Fi # Wi-Fi Card
 
   # CPU fan
   # For Linux/MacOS platforms, the CPU fan is amongst all fan sensors gathered from the motherboard chipset
@@ -40,7 +39,7 @@ config:
 
   # OpenWeatherMap API KEY. Can be obtained by creating a free account on https://home.openweathermap.org/users/sign_up.
   # You need to subscribe to the 3.0 OneCallAPI that has 1000 free daily calls
-  WEATHER_API_KEY: ""
+  WEATHER_API_KEY: ''
   # Location from which to display the weather. Use for example https://www.latlong.net/ to get latitude/longitude
   WEATHER_LATITUDE: 45.75
   WEATHER_LONGITUDE: 4.85
@@ -68,4 +67,7 @@ display:
   # Display reverse: true/false
   # Set to true to reverse display orientation (landscape <-> reverse landscape, portrait <-> reverse portrait)
   # Note: Display basic orientation (portrait or landscape) is defined by the theme you have selected
-  DISPLAY_REVERSE: false
+  DISPLAY_REVERSE: true
+
+  # https://github.com/mathoudebine/turing-smart-screen-python/wiki/Hardware-revisions#with-separate-mainboard
+  WORKAROUND_RESET: Y

--- a/library/display.py
+++ b/library/display.py
@@ -74,11 +74,13 @@ class Display:
             self.lcd = LcdSimulated(display_width=480,
                                     display_height=800)
         else:
-            logger.error("Unknown display revision '", config.CONFIG_DATA["display"]["REVISION"], "'")
+            logger.error("Unknown display revision '",
+                         config.CONFIG_DATA["display"]["REVISION"], "'")
 
     def initialize_display(self):
         # Reset screen in case it was in an unstable state (screen is also cleared)
-        self.lcd.Reset()
+        if config.CONFIG_DATA["display"]["WORKAROUND_RESET"] != "Y":
+            self.lcd.Reset()
 
         # Send initialization commands
         self.lcd.InitializeComm()
@@ -97,7 +99,8 @@ class Display:
         self.lcd.SetBrightness(config.CONFIG_DATA["display"]["BRIGHTNESS"])
 
         # Set backplate RGB LED color (for supported HW only)
-        self.lcd.SetBackplateLedColor(config.THEME_DATA['display'].get("DISPLAY_RGB_LED", (255, 255, 255)))
+        self.lcd.SetBackplateLedColor(
+            config.THEME_DATA['display'].get("DISPLAY_RGB_LED", (255, 255, 255)))
 
     def turn_off(self):
         # Turn screen off
@@ -111,11 +114,14 @@ class Display:
             for image in config.THEME_DATA['static_images']:
                 logger.debug(f"Drawing Image: {image}")
                 self.lcd.DisplayBitmap(
-                    bitmap_path=config.THEME_DATA['PATH'] + config.THEME_DATA['static_images'][image].get("PATH"),
+                    bitmap_path=config.THEME_DATA['PATH'] +
+                    config.THEME_DATA['static_images'][image].get("PATH"),
                     x=config.THEME_DATA['static_images'][image].get("X", 0),
                     y=config.THEME_DATA['static_images'][image].get("Y", 0),
-                    width=config.THEME_DATA['static_images'][image].get("WIDTH", 0),
-                    height=config.THEME_DATA['static_images'][image].get("HEIGHT", 0)
+                    width=config.THEME_DATA['static_images'][image].get(
+                        "WIDTH", 0),
+                    height=config.THEME_DATA['static_images'][image].get(
+                        "HEIGHT", 0)
                 )
 
     def display_static_text(self):
@@ -126,17 +132,26 @@ class Display:
                     text=config.THEME_DATA['static_text'][text].get("TEXT"),
                     x=config.THEME_DATA['static_text'][text].get("X", 0),
                     y=config.THEME_DATA['static_text'][text].get("Y", 0),
-                    width=config.THEME_DATA['static_text'][text].get("WIDTH", 0),
-                    height=config.THEME_DATA['static_text'][text].get("HEIGHT", 0),
-                    font=config.FONTS_DIR + config.THEME_DATA['static_text'][text].get("FONT", "roboto-mono/RobotoMono-Regular.ttf"),
-                    font_size=config.THEME_DATA['static_text'][text].get("FONT_SIZE", 10),
-                    font_color=config.THEME_DATA['static_text'][text].get("FONT_COLOR", (0, 0, 0)),
-                    background_color=config.THEME_DATA['static_text'][text].get("BACKGROUND_COLOR", (255, 255, 255)),
+                    width=config.THEME_DATA['static_text'][text].get(
+                        "WIDTH", 0),
+                    height=config.THEME_DATA['static_text'][text].get(
+                        "HEIGHT", 0),
+                    font=config.FONTS_DIR +
+                    config.THEME_DATA['static_text'][text].get(
+                        "FONT", "roboto-mono/RobotoMono-Regular.ttf"),
+                    font_size=config.THEME_DATA['static_text'][text].get(
+                        "FONT_SIZE", 10),
+                    font_color=config.THEME_DATA['static_text'][text].get(
+                        "FONT_COLOR", (0, 0, 0)),
+                    background_color=config.THEME_DATA['static_text'][text].get(
+                        "BACKGROUND_COLOR", (255, 255, 255)),
                     background_image=_get_full_path(config.THEME_DATA['PATH'],
                                                     config.THEME_DATA['static_text'][text].get("BACKGROUND_IMAGE",
                                                                                                None)),
-                    align=config.THEME_DATA['static_text'][text].get("ALIGN", "left"),
-                    anchor=config.THEME_DATA['static_text'][text].get("ANCHOR", "lt"),
+                    align=config.THEME_DATA['static_text'][text].get(
+                        "ALIGN", "left"),
+                    anchor=config.THEME_DATA['static_text'][text].get(
+                        "ANCHOR", "lt"),
                 )
 
 


### PR DESCRIPTION
As per title, implemented a configuration option to workaround quoted on: https://github.com/mathoudebine/turing-smart-screen-python/wiki/Hardware-revisions#with-separate-mainboard