### PR TITLE
Upgraded options with search and autofill city latitude and longitude with geoapi

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -728,12 +728,15 @@ class MoreConfigWindow:
         cb_entries = []
         for entry in request.json():
             name = entry['name']
-            state = entry['state']
+            state = entry.get('state', None)
             lat = entry['lat']
             long = entry['lon']
             country_code = entry['country'].upper()
             country = babel.Locale(lang).territories[country_code]
-            full_name = f"{name}, {state}, {country}"
+            if state is not None:
+                full_name = f"{name}, {state}, {country}"
+            else:
+                full_name = f"{name}, {country}"
             self._city_entries.append({"full_name": full_name, "lat": str(lat), "long": str(long)})
             cb_entries.append(full_name)
 


### PR DESCRIPTION
Updated configure.py to add search option for a given city/location and autofill lat/long boxes from one of selected search results.

The "Weather & Ping" config option has now entry field to enter location to search, and combobox with results + button to fill in selected result coordinates (for multiple locations like London in United Kingdom and London in Canada).

The results are pulled using openweathermap Geo API, and require entering valid API key.
The search results are also selected language agnostic, resulting in localized country and state names.