### PR TITLE
Fan max RPM is hardcoded to 1500. There are fans of 1500, 2200 and 3000

### DIFF
--- a/library/sensors/sensors_python.py
+++ b/library/sensors/sensors_python.py
@@ -84,10 +84,19 @@ def sensors_fans():
     for base in basenames:
         try:
             current_rpm = int(bcat(base + '_input'))
+
             try:
                 max_rpm = int(bcat(base + '_max'))
             except:
-                max_rpm = 1500  # Approximated: max fan speed is 1500 RPM
+                max_rpm = False  # Real maximum speed not found
+            if not max_rpm:
+                if current_rpm > 2200:
+                    max_rpm = 3000  # AIO Pumps are usualy 3000 RPM
+                elif current_rpm > 1500:
+                    max_rpm = 2200  # High speed fans are usualy 2200 RPM
+                else
+                    max_rpm = 1500  # Approximated: max fan speed is 1500 RPM
+
             try:
                 min_rpm = int(bcat(base + '_min'))
             except:


### PR DESCRIPTION
Try to improbe the assumption that fan maximum speed is always 1500 RPM

There are high speed fans usually running at a maximum speed of 2200 RPM and pumps that usually are running at maximum speeds of 3000 RPM

This is not perfect, but a better aproach to the issue as we don't have any information available about the type of the fan we are processing.