### PR TITLE
Fix "Open theme" button double path concat

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -456,9 +456,9 @@ class TuringConfigWindow:
         self.more_config_window.show()
 
     def on_open_theme_folder_click(self):
-        path = f'"{MAIN_DIRECTORY}res/themes"'
+        path = f'{MAIN_DIRECTORY}res/themes'
         if platform.system() == "Windows":
-            os.startfile(path)
+            os.startfile(f'"{path}"')
         elif platform.system() == "Darwin":
             subprocess.Popen(["open", path])
         else:


### PR DESCRIPTION
On Manjaro ran into issue that open theme button tries to open `{pwd}/{theme_dir}` (i.e. `/home/user/repo/"/home/user/repo/res/themes"`). 

Found that this is due to essentially double quoting the arguments of `subprocess.Popen`. 
`subprocess.Popen` arguments do not need to have extra quotes applied ([the documentation recommends validating this with shlex.split()](https://docs.python.org/3/library/subprocess.html#popen-constructor)).

The submitted change affects only the subprocess.Popen calls and leaves Windows as it was.

Fixes #868 