### PR TITLE
Added min/max formatter to DisplayLineGraph()

### DIFF
--- a/library/lcd/lcd_comm.py
+++ b/library/lcd/lcd_comm.py
@@ -380,7 +380,8 @@ class LcdComm(ABC):
                          axis_font: str = "./res/fonts/roboto/Roboto-Black.ttf",
                          axis_font_size: int = 10,
                          background_color: Color = (255, 255, 255),
-                         background_image: Optional[str] = None):
+                         background_image: Optional[str] = None,
+                         axis_minmax_format: str = "{:0.0f}"):
         # Generate a plot graph and display it
         # Provide the background image path to display plot graph with transparent background
 
@@ -451,13 +452,13 @@ class LcdComm(ABC):
 
             # Draw Legend
             draw.line([0, 0, 1, 0], fill=axis_color)
-            text = f"{int(max_value)}"
+            text = axis_minmax_format.format(max_value)
             ttfont = self.open_font(axis_font, axis_font_size)
             _, top, right, bottom = ttfont.getbbox(text)
             draw.text((2, 0 - top), text,
                       font=ttfont, fill=axis_color)
 
-            text = f"{int(min_value)}"
+            text = axis_minmax_format.format(min_value)
             _, top, right, bottom = ttfont.getbbox(text)
             draw.text((width - 1 - right, height - 2 - bottom), text,
                       font=ttfont, fill=axis_color)


### PR DESCRIPTION
Typically useful for CPU Load where min/max can be usually within 0 to 1 and end up displayed as "0" because of the cast to int.
Default formatter is equivalent to existing, but you can override the parameter and set to "{:0.2f}" to see "0.12" on the bar graph min/max for instance.