### PR TITLE
FIX in DisplayLineGraph, in case min==max it gives div by zero. 

### DIFF
--- a/library/lcd/lcd_comm.py
+++ b/library/lcd/lcd_comm.py
@@ -420,7 +420,7 @@ class LcdComm(ABC):
 
         step = width / len(values)
         # pre compute yScale multiplier value
-        yScale = height / (max_value - min_value)
+        yScale = (height / (max_value - min_value)) if (max_value - min_value) != 0 else 0
 
         plotsX = []
         plotsY = []


### PR DESCRIPTION
Fixed the edge case of scaling autocalculation by setting a factor of zero if min==max.
This is useful in case the list is a list full of zeroes for instance : service died, has some no activity period, is not always started, initialized with zeroes, etc. 