### PR TITLE
feat: Adding path support for disk storage display

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,9 @@ config:
   # Choose a theme made for your screen size (see DISPLAY_SIZE inside theme.yaml)
   THEME: 3.5inchTheme2
 
+  # Filesystem path used for disk usage statistics
+  DISK_PATH: "/"
+
   # Hardware sensors reading
   # Choose the appropriate method for reading your hardware sensors:
   # - PYTHON         use Python libraries (psutils, GPUtil...) to read hardware sensors (supports all OS but not all HW)

--- a/library/sensors/sensors.py
+++ b/library/sensors/sensors.py
@@ -105,17 +105,17 @@ class Memory(ABC):
 class Disk(ABC):
     @staticmethod
     @abstractmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path: str = "/") -> float:
         pass
 
     @staticmethod
     @abstractmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path: str = "/") -> int:  # In bytes
         pass
 
     @staticmethod
     @abstractmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path: str = "/") -> int:  # In bytes
         pass
 
 

--- a/library/sensors/sensors_librehardwaremonitor.py
+++ b/library/sensors/sensors_librehardwaremonitor.py
@@ -450,16 +450,16 @@ class Memory(sensors.Memory):
 # This is because LHM is a hardware-oriented library, whereas used/free/total space is for partitions, not disks
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
-        return psutil.disk_usage("/").percent
+    def disk_usage_percent(path: str = "/") -> float:
+        return psutil.disk_usage(path).percent
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
-        return psutil.disk_usage("/").used
+    def disk_used(path: str = "/") -> int:  # In bytes
+        return psutil.disk_usage(path).used
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
-        return psutil.disk_usage("/").free
+    def disk_free(path: str = "/") -> int:  # In bytes
+        return psutil.disk_usage(path).free
 
 
 class Net(sensors.Net):

--- a/library/sensors/sensors_python.py
+++ b/library/sensors/sensors_python.py
@@ -453,23 +453,23 @@ class Memory(sensors.Memory):
 
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path: str = "/") -> float:
         try:
-            return psutil.disk_usage("/").percent
+            return psutil.disk_usage(path).percent
         except:
             return math.nan
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path: str = "/") -> int:  # In bytes
         try:
-            return psutil.disk_usage("/").used
+            return psutil.disk_usage(path).used
         except:
             return -1
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path: str = "/") -> int:  # In bytes
         try:
-            return psutil.disk_usage("/").free
+            return psutil.disk_usage(path).free
         except:
             return -1
 

--- a/library/sensors/sensors_stub_random.py
+++ b/library/sensors/sensors_stub_random.py
@@ -93,15 +93,15 @@ class Memory(sensors.Memory):
 
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path: str = "/") -> float:
         return random.uniform(0, 100)
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path: str = "/") -> int:  # In bytes
         return random.randint(1000000000, 2000000000000)
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path: str = "/") -> int:  # In bytes
         return random.randint(1000000000, 2000000000000)
 
 

--- a/library/sensors/sensors_stub_static.py
+++ b/library/sensors/sensors_stub_static.py
@@ -109,15 +109,15 @@ class Memory(sensors.Memory):
 
 class Disk(sensors.Disk):
     @staticmethod
-    def disk_usage_percent() -> float:
+    def disk_usage_percent(path: str = "/") -> float:
         return PERCENTAGE_SENSOR_VALUE
 
     @staticmethod
-    def disk_used() -> int:  # In bytes
+    def disk_used(path: str = "/") -> int:  # In bytes
         return int(DISK_TOTAL_SIZE_GB / 100 * PERCENTAGE_SENSOR_VALUE) * 1000000000
 
     @staticmethod
-    def disk_free() -> int:  # In bytes
+    def disk_free(path: str = "/") -> int:  # In bytes
         return int(DISK_TOTAL_SIZE_GB / 100 * (100 - PERCENTAGE_SENSOR_VALUE)) * 1000000000
 
 

--- a/library/stats.py
+++ b/library/stats.py
@@ -647,12 +647,16 @@ class Disk:
 
     @classmethod
     def stats(cls):
-        used = sensors.Disk.disk_used()
-        free = sensors.Disk.disk_free()
-
         disk_theme_data = config.THEME_DATA['STATS']['DISK']
+        
+        path = "/"
+        if disk_theme_data['PATH'] is not None:
+            path = disk_theme_data['PATH']
 
-        disk_usage_percent = sensors.Disk.disk_usage_percent()
+        used = sensors.Disk.disk_used(path)
+        free = sensors.Disk.disk_free(path)
+
+        disk_usage_percent = sensors.Disk.disk_usage_percent(path)
         save_last_value(disk_usage_percent, cls.last_values_disk_usage,
                         disk_theme_data['USED']['LINE_GRAPH'].get("HISTORY_SIZE", DEFAULT_HISTORY_SIZE))
         display_themed_progress_bar(disk_theme_data['USED']['GRAPH'], disk_usage_percent)

--- a/library/stats.py
+++ b/library/stats.py
@@ -648,10 +648,7 @@ class Disk:
     @classmethod
     def stats(cls):
         disk_theme_data = config.THEME_DATA['STATS']['DISK']
-        
-        path = "/"
-        if disk_theme_data['PATH'] is not None:
-            path = disk_theme_data['PATH']
+        path = config.CONFIG_DATA['config'].get('DISK_PATH') or "/"
 
         used = sensors.Disk.disk_used(path)
         free = sensors.Disk.disk_free(path)


### PR DESCRIPTION
The current implementation only read disk storage for the root path "/'
I added support for it so that you can optionally custom define path for your theme
It is more important for me to know the mounted storage in my use case that's why I want this functionality

For the theme setting, we can have the additional `PATH` attribute for `DISK` in `theme.yaml`

```yaml
STAT:
  DISK:
    INTERVAL: 10
    PATH: /mnt/data            # ← New optional parameter
    USED:
      RADIAL:
        SHOW: True
        X: 225
        Y: 385
```