### PR TITLE
Update maximum supported Python version to 3.14

### DIFF
--- a/library/pythoncheck.py
+++ b/library/pythoncheck.py
@@ -24,7 +24,7 @@ import sys
 
 # Oldest / newest version supported
 MIN_PYTHON = (3, 9)
-MAX_PYTHON = (3, 13)
+MAX_PYTHON = (3, 14)
 
 
 def check_python_version():


### PR DESCRIPTION
Tested on Void Linux that just pulled Python 3.14: works just fine with the current requirements, GPUtil builds cleanly too.