### PR TITLE
Fix DisplayProgressBar horizontal bar filling wrong side (fixes #982)

### DIFF
--- a/library/lcd/lcd_comm.py
+++ b/library/lcd/lcd_comm.py
@@ -378,7 +378,7 @@ class LcdComm(ABC):
             if reverse_direction is True:
                 x1 = width - bar_filled_width
             else:
-                x1 = bar_filled_width
+                x2 = bar_filled_width
         else:
             if reverse_direction is True:
                 y2 = height - bar_filled_height


### PR DESCRIPTION
## Summary

Fixes #982 — horizontal progress bars rendered the empty portion in `BAR_COLOR` instead of the filled portion.

## Root cause

In commit `db59686` ("refactor code, inverse now a graph setting"), `DisplayProgressBar()` was refactored to use shared `x1/y1/x2/y2` defaults (`x1=0, y1=0, x2=width-1, y2=height-1`) and assign one coordinate per branch. The horizontal non-reverse branch assigned the wrong one:

```python
if width > height:
    if reverse_direction is True:
        x1 = width - bar_filled_width   # correct — draws [w-bfw, 0, w-1, h-1]
    else:
        x1 = bar_filled_width           # BUG — draws [bfw, 0, w-1, h-1] (empty side)
```

Pre-refactor code drew `rectangle([0, 0, bar_filled_width, height - 1], fill=bar_color)` — i.e. `x2` was the variable being assigned, not `x1`.

## Fix

One-line change: assign `x2 = bar_filled_width` instead of `x1`. The vertical branches and the `reverse_direction=True` horizontal branch were already correct after the refactor and are unchanged.

## Testing

Verified on a UsbMonitor 3.5" (Revision A) with the DragonBall theme — horizontal CPU/DISK/GPU bars now fill from the left as expected, matching pre-refactor behavior.