### PR TITLE
DisplayProgressBar: honour min_value when computing fill width

### DIFF
--- a/library/lcd/lcd_comm.py
+++ b/library/lcd/lcd_comm.py
@@ -357,13 +357,17 @@ class LcdComm(ABC):
             # Crop bitmap to keep only the progress bar background
             bar_image = bar_image.crop(box=(x, y, x + width, y + height))
 
-        # Draw progress bar
+        # Draw progress bar. Fill has to be computed from the offset
+        # into [min_value, max_value], not the raw value; otherwise a
+        # bar with min_value > 0 (e.g. a 25..95 temperature bar) is
+        # filled by the wrong fraction. DisplayRadialProgressBar below
+        # already does this correctly. See issue #954.
         if width > height:
-            bar_filled_width = (value / (max_value - min_value) * width) - 1
+            bar_filled_width = ((value - min_value) / (max_value - min_value) * width) - 1
             if bar_filled_width < 0:
                 bar_filled_width = 0
         else:
-            bar_filled_height = (value / (max_value - min_value) * height) - 1
+            bar_filled_height = ((value - min_value) / (max_value - min_value) * height) - 1
             if bar_filled_height < 0:
                 bar_filled_height = 0
         draw = ImageDraw.Draw(bar_image)


### PR DESCRIPTION
Fixes #954.

## Problem

`DisplayProgressBar` in `library/lcd/lcd_comm.py` computes the filled extent from the raw value, not the value's offset from `min_value`:

```python
bar_filled_width = (value / (max_value - min_value) * width) - 1
```

When `min_value == 0` (default) this is correct, which is why the bug has gone unnoticed. For any bar with a non-zero minimum (e.g. a 25..95 temperature bar) the fill is wrong:

| value | min | max | buggy fill | correct fill |
|-------|-----|-----|-----------|-------------|
| 25    | 25  | 95  | 36%       | 0%          |
| 60    | 25  | 95  | 86%       | 50%         |
| 95    | 25  | 95  | 136%      | 100%        |

`DisplayRadialProgressBar` (around line 560) already uses the offset-from-min form:

```python
pct = (value - min_value) / (max_value - min_value)
```

## Fix

Subtract `min_value` in both the horizontal and vertical branches of `DisplayProgressBar` so the two bar primitives agree. One-character change per branch.

Signed off per DCO.
