### PR TITLE
Fix DisplayProgressBar min_value offset in fill calculation

### DIFF
--- a/library/lcd/lcd_comm.py
+++ b/library/lcd/lcd_comm.py
@@ -359,11 +359,11 @@ class LcdComm(ABC):
 
         # Draw progress bar
         if width > height:
-            bar_filled_width = (value / (max_value - min_value) * width) - 1
+            bar_filled_width = ((value - min_value) / (max_value - min_value) * width) - 1
             if bar_filled_width < 0:
                 bar_filled_width = 0
         else:
-            bar_filled_height = (value / (max_value - min_value) * height) - 1
+            bar_filled_height = ((value - min_value) / (max_value - min_value) * height) - 1
             if bar_filled_height < 0:
                 bar_filled_height = 0
         draw = ImageDraw.Draw(bar_image)


### PR DESCRIPTION
Fixes #954.

`DisplayProgressBar` calculated the filled width/height from the raw value rather than the value's offset from `min_value`:

```python
# Before
bar_filled_width = (value / (max_value - min_value) * width) - 1

# After
bar_filled_width = ((value - min_value) / (max_value - min_value) * width) - 1
```

When `min_value` is 0 (the default), this has no effect — which is why the bug went unnoticed. For any bar with a non-zero minimum (e.g. a temperature bar with min=25, max=95), the fill is wrong:

| value | min | max | buggy fill | correct fill |
|-------|-----|-----|------------|--------------|
| 25    | 25  | 95  | 36%        | 0%           |
| 60    | 25  | 95  | 86%        | 50%          |
| 95    | 25  | 95  | 136%       | 100%         |

`DisplayRadialProgressBar` already uses the correct form (`(value - min_value) / (max_value - min_value)`).

Both the horizontal (`bar_filled_width`) and vertical (`bar_filled_height`) branches had the same bug — both are fixed in this PR.