### PR TITLE
Correction tray_icon sur kubuntu

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,16 +1,15 @@
----
 config:
   # Configuration values to set up basic communication
   # Set your COM port e.g. COM3 for Windows, /dev/ttyACM0 for Linux...
   # Use AUTO for COM port auto-discovery (may not work on every setup) or if device is not detected as a COM port
   # COM_PORT: "/dev/ttyACM0"
   # COM_PORT: "COM3"
-  COM_PORT: "AUTO"
+  COM_PORT: AUTO
 
   # Theme to use (located in res/themes)
   # Use the name of the folder as value
   # Choose a theme made for your screen size (see DISPLAY_SIZE inside theme.yaml)
-  THEME: 3.5inchTheme2
+  THEME: Cyberpunk-net
 
   # Hardware sensors reading
   # Choose the appropriate method for reading your hardware sensors:
@@ -18,21 +17,21 @@ config:
   # - LHM            use LibreHardwareMonitor library to read hardware sensors (Windows only - NEEDS ADMIN RIGHTS)
   # - STUB / STATIC  use random/static data instead of real hardware sensors
   # - AUTO           use the best method based on your OS: Windows OS will use LHM, other OS will use Python libraries
-  HW_SENSORS: AUTO
+  HW_SENSORS: PYTHON
 
   # Network interfaces
   # Linux/MacOS interfaces are named "eth0", "wlan0", "wlp1s0", "enp2s0"...
   # For Windows use the interfaces pretty name: "Ethernet 2", "Wi-Fi", ...
   # Leave the fields empty if the card does not exist on your setup
-  ETH: "" # Ethernet Card
-  WLO: "" # Wi-Fi Card
+  ETH: '' # Ethernet Card
+  WLO: wlp4s0 # Wi-Fi Card
 
   # CPU fan
   # For Linux/MacOS platforms, the CPU fan is amongst all fan sensors gathered from the motherboard chipset
   # If value is AUTO the system monitor will try to auto-select the CPU fan
   # If auto-detection fails, it might be necessary to manually indicate which fan is the CPU fan
   # Value must be 'controller/fan' e.g. 'nct6798/fan2'. Use configuration wizard for help in selection
-  CPU_FAN: AUTO
+  CPU_FAN: amdgpu/fan1
 
   # Address used for ping sensor. Can be internal/external IP (e.g. 8.8.8.8 or 192.168.0.1) or hostname (google.com)
   PING: 8.8.8.8
@@ -41,7 +40,7 @@ config:
 
   # OpenWeatherMap API KEY. Can be obtained by creating a free account on https://home.openweathermap.org/users/sign_up.
   # You need to subscribe to the 3.0 OneCallAPI that has 1000 free daily calls
-  WEATHER_API_KEY: ""
+  WEATHER_API_KEY: ''
   # Location from which to display the weather. Use for example https://www.latlong.net/ to get latitude/longitude
   WEATHER_LATITUDE: 45.75
   WEATHER_LONGITUDE: 4.85
@@ -66,7 +65,7 @@ display:
   # Display Brightness
   # Set this as the desired %, 0 being completely dark and 100 being max brightness
   # Warning: revision A display can get hot at high brightness!
-  BRIGHTNESS: 20
+  BRIGHTNESS: 40
 
   # Display reverse: true/false
   # Set to true to reverse display orientation (landscape <-> reverse landscape, portrait <-> reverse portrait)

--- a/configure.py
+++ b/configure.py
@@ -83,7 +83,7 @@ SIZE_2_8_INCH_NEWREV = "2.8\" round (V1.X new HW rev.)"
 size_list = (
     SIZE_0_96_INCH,
     SIZE_2_x_INCH,
-    SIZE_2_8_ROUND_USB,
+    SIZE_2_8_INCH_NEWREV,
     SIZE_3_5_INCH,
     SIZE_4_6_INCH,
     SIZE_5_INCH,
@@ -110,7 +110,7 @@ revision_and_size_to_model_map = {
     ('TUR_USB', SIZE_8_8_INCH): TURING_MODEL,
     ('TUR_USB', SIZE_8_8_INCH_NEWREV): TURING_MODEL,
     ('TUR_USB', SIZE_12_3_INCH): TURING_MODEL,
-    ('TUR_USB', SIZE_2_8_ROUND_USB): TURING_MODEL,
+    ('TUR_USB', SIZE_2_8_INCH_NEWREV): TURING_MODEL,
     ('WEACT_A', SIZE_3_5_INCH): WEACT_MODEL,
     ('WEACT_B', SIZE_0_96_INCH): WEACT_MODEL,
 
@@ -135,7 +135,7 @@ model_and_size_to_revision_map = {
     (TURING_MODEL, SIZE_8_8_INCH): 'C',
     (TURING_MODEL, SIZE_8_8_INCH_NEWREV): 'TUR_USB',
     (TURING_MODEL, SIZE_12_3_INCH): 'TUR_USB',
-    (TURING_MODEL, SIZE_2_8_ROUND_USB): 'TUR_USB',
+    (TURING_MODEL, SIZE_2_8_INCH_NEWREV): 'TUR_USB',
     (USBPCMONITOR_MODEL, SIZE_3_5_INCH): 'A',
     (USBPCMONITOR_MODEL, SIZE_5_INCH): 'A',
     (WEACT_MODEL, SIZE_0_96_INCH): 'WEACT_B',
@@ -474,7 +474,7 @@ class TuringConfigWindow:
             if size == SIZE_8_8_INCH and self.config['display']['REVISION'] == 'TUR_USB':
                 size = SIZE_8_8_INCH_NEWREV
             if size == SIZE_2_x_INCH and self.config['display']['REVISION'] == 'TUR_USB':
-                size = SIZE_2_8_ROUND_USB
+                size = SIZE_2_8_INCH_NEWREV
             self.size_cb.set(size)
         except:
             self.size_cb.current(0)
@@ -622,7 +622,7 @@ class TuringConfigWindow:
         size = self.size_cb.get()
 
         # For '2.1" / 2.8"' size, search for themes of both sizes
-        if size == SIZE_2_x_INCH or size == SIZE_2_8_ROUND_USB:
+        if size == SIZE_2_x_INCH or size == SIZE_2_8_INCH_NEWREV:
             themes = get_themes(_SIZE_2_1_INCH)
             themes += get_themes(_SIZE_2_8_INCH)
         # For 8.8" & 9.2" sizes, search for themes of both sizes

--- a/main.py
+++ b/main.py
@@ -101,17 +101,14 @@ if __name__ == "__main__":
 
         # Remove tray icon just before exit
         if tray_icon:
-            tray_icon.visible = False
+            tray_icon.stop()
+            time.sleep(0.5)
 
         # We force the exit to avoid waiting for other scheduled tasks: they may have a long delay!
         try:
             sys.exit(0)
         except:
             os._exit(0)
-
-    def on_signal_caught(signum, frame=None):
-        logger.info("Caught signal %d, exiting" % signum)
-        clean_stop()
 
     def on_configure_tray(tray_icon, item):
         logger.info("Configure from tray icon")
@@ -134,39 +131,6 @@ if __name__ == "__main__":
         logger.info("Exit from tray icon")
         clean_stop(tray_icon)
 
-
-    def on_clean_exit(*args):
-        logger.info("Program will now exit")
-        clean_stop()
-
-
-    if platform.system() == "Windows":
-        def on_win32_ctrl_event(event):
-            """Handle Windows console control events (like Ctrl-C)."""
-            if event in (win32con.CTRL_C_EVENT, win32con.CTRL_BREAK_EVENT, win32con.CTRL_CLOSE_EVENT):
-                logger.debug("Caught Windows control event %s, exiting" % event)
-                clean_stop()
-            return 0
-
-
-        def on_win32_wm_event(hWnd, msg, wParam, lParam):
-            """Handle Windows window message events (like ENDSESSION, CLOSE, DESTROY)."""
-            logger.debug("Caught Windows window message event %s" % msg)
-            if msg == win32con.WM_POWERBROADCAST:
-                # WM_POWERBROADCAST is used to detect computer going to/resuming from sleep
-                if wParam == win32con.PBT_APMSUSPEND:
-                    logger.info("Computer is going to sleep, display will turn off")
-                    display.turn_off()
-                elif wParam == win32con.PBT_APMRESUMEAUTOMATIC:
-                    logger.info("Computer is resuming from sleep, display will turn on")
-                    display.turn_on()
-                    # Some models have troubles displaying back the previous bitmap after being turned off/on
-                    display.display_static_images()
-                    display.display_static_text()
-            else:
-                # For any other events, the program will stop
-                logger.info("Program will now exit")
-                clean_stop()
 
     # Create a tray icon for the program, with an Exit entry in menu
     try:
@@ -194,6 +158,42 @@ if __name__ == "__main__":
         logger.warning("Tray icon is not supported on your platform")
 
     # Set the different stopping event handlers, to send a complete frame to the LCD before exit
+    def on_clean_exit(*args):
+        logger.info("Program will now exit")
+        clean_stop(tray_icon)
+
+    def on_signal_caught(signum, frame=None):
+        logger.info("Caught signal %d, exiting" % signum)
+        clean_stop(tray_icon)
+
+    if platform.system() == "Windows":
+        def on_win32_ctrl_event(event):
+            """Handle Windows console control events (like Ctrl-C)."""
+            if event in (win32con.CTRL_C_EVENT, win32con.CTRL_BREAK_EVENT, win32con.CTRL_CLOSE_EVENT):
+                logger.debug("Caught Windows control event %s, exiting" % event)
+                clean_stop(tray_icon)
+            return 0
+
+
+        def on_win32_wm_event(hWnd, msg, wParam, lParam):
+            """Handle Windows window message events (like ENDSESSION, CLOSE, DESTROY)."""
+            logger.debug("Caught Windows window message event %s" % msg)
+            if msg == win32con.WM_POWERBROADCAST:
+                # WM_POWERBROADCAST is used to detect computer going to/resuming from sleep
+                if wParam == win32con.PBT_APMSUSPEND:
+                    logger.info("Computer is going to sleep, display will turn off")
+                    display.turn_off()
+                elif wParam == win32con.PBT_APMRESUMEAUTOMATIC:
+                    logger.info("Computer is resuming from sleep, display will turn on")
+                    display.turn_on()
+                    # Some models have troubles displaying back the previous bitmap after being turned off/on
+                    display.display_static_images()
+                    display.display_static_text()
+            else:
+                # For any other events, the program will stop
+                logger.info("Program will now exit")
+                clean_stop(tray_icon)
+
     atexit.register(on_clean_exit)
     signal.signal(signal.SIGINT, on_signal_caught)
     signal.signal(signal.SIGTERM, on_signal_caught)


### PR DESCRIPTION
I found a bug in Kubuntu (Wayland).
When you run `configure.py` and click “Save & Exit” or force it to stop with Ctrl+C, the tray icon sometimes remains active.
I fixed the bug.