### PR TITLE
Add Python 3.14 support on Windows

### DIFF
--- a/.github/workflows/generate-windows-packages-debug.yml
+++ b/.github/workflows/generate-windows-packages-debug.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/generate-windows-packages.yml
+++ b/.github/workflows/generate-windows-packages.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/simple-program-windows.yml
+++ b/.github/workflows/simple-program-windows.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/system-monitor-windows.yml
+++ b/.github/workflows/system-monitor-windows.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         theme: [ "3.5inchTheme2" ]
 
     steps:

--- a/library/pythoncheck.py
+++ b/library/pythoncheck.py
@@ -24,10 +24,7 @@ import sys
 
 # Oldest / newest version supported
 MIN_PYTHON = (3, 9)
-# For Windows: max Python 3.13 until PythonNet support for 3.14
-MAX_PYTHON_WINDOWS = (3, 13)
-MAX_PYTHON_OTHERS = (3, 14)
-MAX_PYTHON = MAX_PYTHON_WINDOWS if sys.platform == "win32" else MAX_PYTHON_OTHERS
+MAX_PYTHON = (3, 14)
 
 
 def check_python_version():

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,5 +39,6 @@ pyamdgpuinfo~=2.1.6; sys_platform=="linux" and python_version <= "3.12"
 pyadl~=0.1; sys_platform=="win32"
 
 # Following packages are for LibreHardwareMonitor integration on Windows
-pythonnet~=3.0.5; sys_platform=="win32"
+pythonnet~=3.0.5; sys_platform=="win32" and python_version < "3.10"   # For Python 3.9, only pythonnet 3.0.x is supported
+pythonnet~=3.1.0; sys_platform=="win32" and python_version >= "3.10"  # For Python 3.10+, pythonnet 3.1.x adds Python 3.14 support
 pywin32>=311; sys_platform=="win32"


### PR DESCRIPTION
Windows was capped at Python 3.13 because pythonnet 3.0.x does not support Python 3.14 (`requires-python >=3.7,<3.14`), which blocked the LibreHardwareMonitor integration. pythonnet 3.1.0 adds Python 3.14 support but drops Python 3.9 (`requires-python >=3.10,<3.15`), so a plain requirement bump (#1009) would break Python 3.9 users. This PR splits the requirement with environment markers instead — the same pattern already used in requirements.txt for requests, Pillow and numpy — so Python 3.9 through 3.14 all resolve to a compatible pythonnet.

Changes:
- requirements.txt: split pythonnet requirement — `~=3.0.5` for Python 3.9, `~=3.1.0` for Python 3.10+ (supersedes #1009)
- library/pythoncheck.py: remove the Windows-specific 3.13 cap, MAX_PYTHON is now 3.14 on all platforms
- Add Python 3.14 to the Windows system-monitor and simple-program CI matrices (3.9-3.13 rows kept)
- Build Windows packages with Python 3.14, matching the Linux packaging workflow

Tested on Windows 11 with Python 3.14.6:
- `pip install -r requirements.txt` resolves the full dependency set with no conflicts
- all sources byte-compile cleanly
- LibreHardwareMonitorLib.dll loads via pythonnet 3.1.0 and hardware enumeration works (CPU detected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
