### PR TITLE
Fix stat widgets freezing permanently after a transient sensor error

### DIFF
--- a/library/scheduler.py
+++ b/library/scheduler.py
@@ -28,8 +28,14 @@ from functools import wraps
 
 import library.config as config
 import library.stats as stats
+from library.log import logger
 
 STOPPING = False
+
+# Some jobs run every millisecond, so a job failing at every run would flood the log file:
+# only log the same failing job once per this delay (in seconds).
+ERROR_LOG_MIN_INTERVAL = 1.0
+_last_error_log = {}
 
 
 def async_job(threadname=None):
@@ -62,7 +68,16 @@ def schedule(interval):
                 # If the program is not stopping: re-schedule the task for future execution
                 scheduler.enter(periodic_interval, 1, periodic,
                                 (scheduler, periodic_interval, action, actionargs))
-            action(*actionargs)
+            # A failing sensor read must not kill this stat's thread: the next run is already
+            # scheduled above, so log the error and keep going.
+            try:
+                action(*actionargs)
+            except Exception:
+                name = getattr(action, "__name__", str(action))
+                now = time.monotonic()
+                if now - _last_error_log.get(name, 0.0) >= ERROR_LOG_MIN_INTERVAL:
+                    _last_error_log[name] = now
+                    logger.exception("Scheduled job '%s' failed, skipping this cycle", name)
 
         @wraps(func)
         def wrap(

--- a/library/stats.py
+++ b/library/stats.py
@@ -121,6 +121,11 @@ def display_themed_value(theme_data, value, min_size=0, unit=''):
 
 
 def display_themed_percent_value(theme_data, value):
+    # A sensor can transiently return nan: int(nan) raises ValueError, which would kill this
+    # stat's thread. Note this happens before the SHOW check below, i.e. even when hidden.
+    if value is None or math.isnan(value):
+        return
+
     display_themed_value(
         theme_data=theme_data,
         value=int(value),
@@ -130,6 +135,9 @@ def display_themed_percent_value(theme_data, value):
 
 
 def display_themed_temperature_value(theme_data, value):
+    if value is None or math.isnan(value):
+        return
+
     display_themed_value(
         theme_data=theme_data,
         value=int(value),
@@ -140,6 +148,9 @@ def display_themed_temperature_value(theme_data, value):
 
 def display_themed_progress_bar(theme_data, value):
     if not theme_data.get("SHOW", False):
+        return
+
+    if value is None or math.isnan(value):
         return
 
     display.lcd.DisplayProgressBar(
@@ -201,6 +212,9 @@ def display_themed_radial_bar(theme_data, value, min_size=0, unit='', custom_tex
 
 
 def display_themed_percent_radial_bar(theme_data, value):
+    if value is None or math.isnan(value):
+        return
+
     display_themed_radial_bar(
         theme_data=theme_data,
         value=int(value),
@@ -210,6 +224,9 @@ def display_themed_percent_radial_bar(theme_data, value):
 
 
 def display_themed_temperature_radial_bar(theme_data, value):
+    if value is None or math.isnan(value):
+        return
+
     display_themed_radial_bar(
         theme_data=theme_data,
         value=int(value),

--- a/library/stats.py
+++ b/library/stats.py
@@ -28,7 +28,7 @@ import math
 import os
 import platform
 import sys
-from typing import List
+from typing import List, Optional
 
 import babel.dates
 import requests
@@ -244,10 +244,14 @@ def display_themed_line_graph(theme_data, values):
     )
 
 
-def save_last_value(value: float, last_values: List[float], history_size: int):
+def save_last_value(value: Optional[float], last_values: List[float], history_size: int):
     # Initialize last values list the first time with given size
     if len(last_values) != history_size:
         last_values[:] = last_values_list(size=history_size)
+    # A sensor may transiently return None: store it as the nan "no data" marker, else
+    # math.isnan() in DisplayLineGraph raises TypeError on every later redraw of this graph.
+    if value is None:
+        value = math.nan
     # Store the value to the list that can then be used for line graph
     last_values.append(value)
     # Also remove the oldest value from list
@@ -925,22 +929,26 @@ class Ping:
         theme_data = config.THEME_DATA['STATS']['PING']
 
         delay = ping(dest_addr=PING_DEST, unit="ms")
+        if delay is None or delay is False:
+            # ping3 returns None on timeout and False on unknown host: no delay to display
+            delay = math.nan
 
         save_last_value(delay, cls.last_values_ping,
                         theme_data['LINE_GRAPH'].get("HISTORY_SIZE", DEFAULT_HISTORY_SIZE))
         # logger.debug(f"Ping delay: {delay}ms")
 
-        display_themed_progress_bar(theme_data['GRAPH'], delay)
-        display_themed_radial_bar(
-            theme_data=theme_data['RADIAL'],
-            value=int(delay),
-            unit="ms",
-            min_size=6
-        )
-        display_themed_value(
-            theme_data=theme_data['TEXT'],
-            value=int(delay),
-            unit="ms",
-            min_size=6
-        )
+        if not math.isnan(delay):
+            display_themed_progress_bar(theme_data['GRAPH'], delay)
+            display_themed_radial_bar(
+                theme_data=theme_data['RADIAL'],
+                value=int(delay),
+                unit="ms",
+                min_size=6
+            )
+            display_themed_value(
+                theme_data=theme_data['TEXT'],
+                value=int(delay),
+                unit="ms",
+                min_size=6
+            )
         display_themed_line_graph(theme_data['LINE_GRAPH'], cls.last_values_ping)

--- a/library/stats.py
+++ b/library/stats.py
@@ -122,6 +122,11 @@ def display_themed_value(theme_data, value, min_size=0, unit=''):
 
 
 def display_themed_percent_value(theme_data, value):
+    # A sensor can transiently return nan: int(nan) raises ValueError, which would kill this
+    # stat's thread. Note this happens before the SHOW check below, i.e. even when hidden.
+    if value is None or math.isnan(value):
+        return
+
     display_themed_value(
         theme_data=theme_data,
         value=int(value),
@@ -131,6 +136,9 @@ def display_themed_percent_value(theme_data, value):
 
 
 def display_themed_temperature_value(theme_data, value):
+    if value is None or math.isnan(value):
+        return
+
     display_themed_value(
         theme_data=theme_data,
         value=int(value),
@@ -141,6 +149,9 @@ def display_themed_temperature_value(theme_data, value):
 
 def display_themed_progress_bar(theme_data, value):
     if not theme_data.get("SHOW", False):
+        return
+
+    if value is None or math.isnan(value):
         return
 
     display.lcd.DisplayProgressBar(
@@ -202,6 +213,9 @@ def display_themed_radial_bar(theme_data, value, min_size=0, unit='', custom_tex
 
 
 def display_themed_percent_radial_bar(theme_data, value):
+    if value is None or math.isnan(value):
+        return
+
     display_themed_radial_bar(
         theme_data=theme_data,
         value=int(value),
@@ -211,6 +225,9 @@ def display_themed_percent_radial_bar(theme_data, value):
 
 
 def display_themed_temperature_radial_bar(theme_data, value):
+    if value is None or math.isnan(value):
+        return
+
     display_themed_radial_bar(
         theme_data=theme_data,
         value=int(value),

--- a/library/stats.py
+++ b/library/stats.py
@@ -29,7 +29,7 @@ import os
 import platform
 import random
 import sys
-from typing import List
+from typing import List, Optional
 
 import babel.dates
 import requests
@@ -245,10 +245,14 @@ def display_themed_line_graph(theme_data, values):
     )
 
 
-def save_last_value(value: float, last_values: List[float], history_size: int):
+def save_last_value(value: Optional[float], last_values: List[float], history_size: int):
     # Initialize last values list the first time with given size
     if len(last_values) != history_size:
         last_values[:] = last_values_list(size=history_size)
+    # A sensor may transiently return None: store it as the nan "no data" marker, else
+    # math.isnan() in DisplayLineGraph raises TypeError on every later redraw of this graph.
+    if value is None:
+        value = math.nan
     # Store the value to the list that can then be used for line graph
     last_values.append(value)
     # Also remove the oldest value from list
@@ -933,22 +937,26 @@ class Ping:
             delay = random.randint(5, 120)
         else:
             delay = ping(dest_addr=PING_DEST, unit="ms")
+            if delay is None or delay is False:
+                # ping3 returns None on timeout and False on unknown host: no delay to display
+                delay = math.nan
 
         save_last_value(delay, cls.last_values_ping,
                         theme_data['LINE_GRAPH'].get("HISTORY_SIZE", DEFAULT_HISTORY_SIZE))
         # logger.debug(f"Ping delay: {delay}ms")
 
-        display_themed_progress_bar(theme_data['GRAPH'], delay)
-        display_themed_radial_bar(
-            theme_data=theme_data['RADIAL'],
-            value=int(delay),
-            unit="ms",
-            min_size=6
-        )
-        display_themed_value(
-            theme_data=theme_data['TEXT'],
-            value=int(delay),
-            unit="ms",
-            min_size=6
-        )
+        if not math.isnan(delay):
+            display_themed_progress_bar(theme_data['GRAPH'], delay)
+            display_themed_radial_bar(
+                theme_data=theme_data['RADIAL'],
+                value=int(delay),
+                unit="ms",
+                min_size=6
+            )
+            display_themed_value(
+                theme_data=theme_data['TEXT'],
+                value=int(delay),
+                unit="ms",
+                min_size=6
+            )
         display_themed_line_graph(theme_data['LINE_GRAPH'], cls.last_values_ping)


### PR DESCRIPTION
## Problem

A stat widget can freeze permanently while the rest of the program keeps running fine. It happens at random, after minutes or hours, and nothing is written to `log.log`.

Three things combine:

**1. A scheduled job that raises kills its thread for good.** Each stat is scheduled in its own thread with its own `sched.scheduler` (`library/scheduler.py`). An exception raised by the job propagates out of `scheduler.run()`, the thread exits and that widget is never updated again. The traceback is invisible in the packaged Windows executable, because `threading.excepthook` writes to `sys.stderr`, which is `None` there.

**2. `ping3` returns `None` instead of a number.** On a ping timeout, `Ping.stats()` raises at `int(delay)`. The `None` is also stored in the line graph history, and `DisplayLineGraph()` calls `math.isnan()` on every stored value, which raises on `None` for as long as the value stays in the buffer.

**3. `int()` is called on values that are `math.nan`.** Sensors already use `math.nan` to report "no value" — LibreHardwareMonitor does it for CPU load and fan speed when it cannot read them — but the display helpers convert with `int()`, which raises `ValueError`. For `display_themed_percent_radial_bar()` and `display_themed_percent_value()` the conversion happens before the `SHOW` check inside the called function, so the stat crashes even when the widget is hidden. This looks like the cause of #718.

Observed on Windows 11 / Python 3.13, `HW_SENSORS: AUTO` (LHM), Wi-Fi connection, `PING: 8.8.8.8`.

Cause 2, during a short network outage:

```
[ERROR] Scheduled job 'PingStats' failed, skipping this cycle
Traceback (most recent call last):
  File "library\scheduler.py", line 195, in PingStats
    stats.Ping.stats()
  File "library\stats.py", line 936, in stats
    value=int(delay),
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

and then, on the following cycles, once the network was back:

```
  File "library\stats.py", line 946, in stats
    display_themed_line_graph(theme_data['LINE_GRAPH'], cls.last_values_ping)
  File "library\lcd\lcd_comm.py", line 458, in DisplayLineGraph
    if not math.isnan(value):
TypeError: must be real number, not NoneType
```

Cause 3, twice in one day, with `RADIAL` not even shown in the theme:

```
[ERROR] Scheduled job 'CPUPercentage' failed, skipping this cycle
Traceback (most recent call last):
  File "library\stats.py", line 284, in percentage
  File "library\stats.py", line 208, in display_themed_percent_radial_bar
ValueError: cannot convert float NaN to integer
```

(the `[ERROR] Scheduled job ...` lines come from this PR; without it the thread dies silently at the first traceback)

## Changes

- `library/scheduler.py`: wrap the scheduled call in `try`/`except`, log the failure and keep going — the next run is already scheduled at that point, so the stat just skips one cycle. Logging is rate-limited to one message per second per job, because `QueueHandler` runs every millisecond and a permanently failing job would otherwise flood `log.log` (which rotates at 1 MB).
- `library/stats.py`: normalize a missing ping delay to `math.nan` and skip, for that cycle, the widgets that need a number. `save_last_value()` maps `None` to `math.nan` as well, so no sensor returning `None` can poison a graph history — `math.nan` is already this code's "no data" marker, see `last_values_list()`.
- `library/stats.py`: skip drawing in the display helpers when the value is `None` or `nan`, instead of letting `int()` raise.

The changes are complementary: the last two remove the two known ways a stat can raise, the first one makes sure that any remaining one only costs a cycle instead of the whole thread, and becomes visible in the log.

`SystemExit` and `KeyboardInterrupt` derive from `BaseException` and are not caught, so the clean shutdown path in `main.py` is unaffected.

Tested on a Turing 5" (rev C) with Windows 11 and Python 3.13.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
