### PR TITLE
Fall back to psutil for network interfaces LibreHardwareMonitor has no sensors for

### DIFF
--- a/library/sensors/sensors_librehardwaremonitor.py
+++ b/library/sensors/sensors_librehardwaremonitor.py
@@ -26,6 +26,7 @@ import ctypes
 import math
 import os
 import sys
+import time
 from statistics import mean
 from typing import Tuple
 
@@ -466,6 +467,9 @@ class Disk(sensors.Disk):
 
 
 class Net(sensors.Net):
+    # Previous psutil counters, per interface: {interface name: (monotonic timestamp, counters)}
+    _psutil_before = {}
+
     @staticmethod
     def stats(if_name, interval) -> Tuple[
         int, int, int, int]:  # up rate (B/s), uploaded (B), dl rate (B/s), downloaded (B)
@@ -477,19 +481,51 @@ class Net(sensors.Net):
 
         if if_name != "":
             net_if = get_net_interface_and_update(if_name)
-            if net_if is not None:
-                for sensor in net_if.Sensors:
-                    if sensor.SensorType == Hardware.SensorType.Data and str(sensor.Name).startswith(
-                            "Data Uploaded") and sensor.Value is not None:
-                        uploaded = int(sensor.Value * 1000000000.0)
-                    elif sensor.SensorType == Hardware.SensorType.Data and str(sensor.Name).startswith(
-                            "Data Downloaded") and sensor.Value is not None:
-                        downloaded = int(sensor.Value * 1000000000.0)
-                    elif sensor.SensorType == Hardware.SensorType.Throughput and str(sensor.Name).startswith(
-                            "Upload Speed") and sensor.Value is not None:
-                        upload_rate = int(sensor.Value)
-                    elif sensor.SensorType == Hardware.SensorType.Throughput and str(sensor.Name).startswith(
-                            "Download Speed") and sensor.Value is not None:
-                        download_rate = int(sensor.Value)
+            # LHM does not expose Data/Throughput sensors for every adapter it reports (e.g. some
+            # Wi-Fi adapters): all values would silently stay at 0 and the network widgets would
+            # display nothing. Read those interfaces from psutil, like disk stats above.
+            if net_if is None or not any(
+                    sensor.SensorType in (Hardware.SensorType.Data, Hardware.SensorType.Throughput)
+                    for sensor in net_if.Sensors):
+                return Net._stats_from_psutil(if_name)
+
+            for sensor in net_if.Sensors:
+                if sensor.SensorType == Hardware.SensorType.Data and str(sensor.Name).startswith(
+                        "Data Uploaded") and sensor.Value is not None:
+                    uploaded = int(sensor.Value * 1000000000.0)
+                elif sensor.SensorType == Hardware.SensorType.Data and str(sensor.Name).startswith(
+                        "Data Downloaded") and sensor.Value is not None:
+                    downloaded = int(sensor.Value * 1000000000.0)
+                elif sensor.SensorType == Hardware.SensorType.Throughput and str(sensor.Name).startswith(
+                        "Upload Speed") and sensor.Value is not None:
+                    upload_rate = int(sensor.Value)
+                elif sensor.SensorType == Hardware.SensorType.Throughput and str(sensor.Name).startswith(
+                        "Download Speed") and sensor.Value is not None:
+                    download_rate = int(sensor.Value)
+
+        return upload_rate, uploaded, download_rate, downloaded
+
+    @staticmethod
+    def _stats_from_psutil(if_name) -> Tuple[
+        int, int, int, int]:  # up rate (B/s), uploaded (B), dl rate (B/s), downloaded (B)
+
+        upload_rate = 0
+        uploaded = 0
+        download_rate = 0
+        downloaded = 0
+
+        counters = psutil.net_io_counters(pernic=True).get(if_name)
+        if counters is not None:
+            now = time.monotonic()
+            before = Net._psutil_before.get(if_name)
+            # Rates are computed from the elapsed time, so they stay correct even if this
+            # interface was not read on the previous cycle.
+            if before is not None and now > before[0]:
+                elapsed = now - before[0]
+                upload_rate = int(max(0, counters.bytes_sent - before[1].bytes_sent) / elapsed)
+                download_rate = int(max(0, counters.bytes_recv - before[1].bytes_recv) / elapsed)
+            uploaded = counters.bytes_sent
+            downloaded = counters.bytes_recv
+            Net._psutil_before[if_name] = (now, counters)
 
         return upload_rate, uploaded, download_rate, downloaded


### PR DESCRIPTION
## Problem

With `HW_SENSORS: LHM` (or `AUTO` on Windows), the network widgets stay empty for some adapters.

LibreHardwareMonitor does enumerate the interface — it is listed at startup as `Found Network interface: <name>` — but exposes no `Data` or `Throughput` sensor for it. `Net.stats()` therefore never assigns a value and silently returns `(0, 0, 0, 0)`: upload/download rates, totals and the network line graphs all render nothing, with no error anywhere.

Reproduced on Windows 11 / Python 3.13 with a Wi-Fi adapter, where `psutil.net_io_counters(pernic=True)` reports correct traffic for the very same interface name.

## Changes

`Net.stats()` now falls back to psutil for interfaces LibreHardwareMonitor has no network sensors for, in the same spirit as the `Disk` class in this file, which already reads everything from psutil.

- The fallback triggers on the **absence** of `Data`/`Throughput` sensors, not on the values being zero. An interface that LHM does support keeps using LHM even while idle, so its "Data Uploaded/Downloaded" totals (counted from program start) are not silently replaced by psutil's counters (counted from boot).
- Rates are computed from the time elapsed between two psutil samples, so they stay correct regardless of the configured `INTERVAL`.
- Interface names need no translation: `configure.py` fills the ETH/WLO fields from `psutil.net_if_addrs()`, so the name in `config.yaml` is already a psutil key.

Tested on a Turing 5" (rev C) with Windows 11 and Python 3.13: the Wi-Fi interface now displays correct rates and totals, and an interface with LHM sensors keeps using LHM.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
