### PR TITLE
Turing USB: coalesce widget updates into rate-limited full-frame sends (~340% -> ~5% CPU)

### DIFF
--- a/library/lcd/lcd_comm_turing_usb.py
+++ b/library/lcd/lcd_comm_turing_usb.py
@@ -25,6 +25,7 @@ import shutil
 import struct
 import subprocess
 import sys
+import threading
 import time
 from io import BytesIO
 from pathlib import Path
@@ -114,8 +115,11 @@ def _encode_jpeg_under_limit(image: Image.Image, *, max_bytes: int, quality: int
 
 
 def send_pil_image_auto(dev, image: Image.Image, *, max_bytes: int = MAX_IMAGE_PAYLOAD_DEFAULT, ) -> None:
-    # First try PNG (preferred)
-    png = _encode_png(image)
+    # This runs up to 2x/sec: use fast PNG compression, the device expects RGBA PNGs
+    # (compress_level=9 takes ~0.5s CPU per frame on photographic themes, level 1 ~25ms)
+    buffer = BytesIO()
+    image.save(buffer, format="PNG", compress_level=1)
+    png = buffer.getvalue()
     if len(png) <= max_bytes:
         send_image(dev, png)
         return
@@ -940,9 +944,38 @@ class LcdCommTuringUSB(LcdComm):
         self.display_width, self.display_height = PRODUCT_ID[self.dev_pid]
         # Store the current screen state as an image that will be continuously updated and sent
         self.current_state = Image.new("RGBA", (self.get_width(), self.get_height()), (0, 0, 0, 0))
+        # The protocol only supports full-screen frames (no partial update), so encoding and
+        # sending the whole frame once per widget refresh pins several CPU cores. Widgets only
+        # paste into current_state; a single thread sends the composed frame at a capped rate.
+        self._state_lock = threading.Lock()
+        self._dev_lock = threading.Lock()
+        self._frame_dirty = threading.Event()
+        self._frame_send_period = 0.5
+        threading.Thread(target=self._frame_sender_loop, name="TuringUSB_Sender", daemon=True).start()
+
+    def _frame_sender_loop(self):
+        while True:
+            self._frame_dirty.wait()
+            self._frame_dirty.clear()
+            with self._state_lock:
+                frame = self.current_state.copy()
+            # Rotate image before sending to screen: all images sent to the screen are in portrait mode
+            if self.orientation == Orientation.LANDSCAPE:
+                frame = frame.transpose(Image.Transpose.ROTATE_270)
+            elif self.orientation == Orientation.REVERSE_LANDSCAPE:
+                frame = frame.transpose(Image.Transpose.ROTATE_90)
+            elif self.orientation == Orientation.PORTRAIT:
+                frame = frame.transpose(Image.Transpose.ROTATE_180)
+            try:
+                with self._dev_lock:
+                    send_pil_image_auto(self.dev, frame, max_bytes=MAX_IMAGE_PAYLOAD_DEFAULT)
+            except Exception:
+                logger.exception("Failed to send frame to Turing USB display")
+            time.sleep(self._frame_send_period)
 
     def InitializeComm(self):
-        send_sync_command(self.dev)
+        with self._dev_lock:
+            send_sync_command(self.dev)
 
     def Reset(self):
         # Do not enable the reset command for now on Turing USB models
@@ -950,7 +983,8 @@ class LcdCommTuringUSB(LcdComm):
         pass
 
     def Clear(self):
-        clear_image(self.dev)
+        with self._dev_lock:
+            clear_image(self.dev)
 
     def ScreenOff(self):
         # Turing USB models do not implement a "screen off" command (that we know of): use SetBrightness(0) instead
@@ -964,12 +998,14 @@ class LcdCommTuringUSB(LcdComm):
     def SetBrightness(self, level: int = 25):
         assert 0 <= level <= 100, 'Brightness level must be [0-100]'
         converted = int(level / 100 * 102)
-        send_brightness_command(self.dev, converted)
+        with self._dev_lock:
+            send_brightness_command(self.dev, converted)
 
     def SetOrientation(self, orientation: Orientation):
         self.orientation = orientation
         # Recreate new state with correct width/height now that screen orientation has changed
-        self.current_state = Image.new("RGBA", (self.get_width(), self.get_height()), (0, 0, 0, 0))
+        with self._state_lock:
+            self.current_state = Image.new("RGBA", (self.get_width(), self.get_height()), (0, 0, 0, 0))
 
     def DisplayPILImage(self, image: Image.Image, x: int = 0, y: int = 0, image_width: int = 0, image_height: int = 0):
         # If the image height/width isn't provided, use the native image size
@@ -986,18 +1022,8 @@ class LcdCommTuringUSB(LcdComm):
         if image_width != image.size[0] or image_height != image.size[1]:
             image = image.crop((0, 0, image_width, image_height))
 
-        # Paste new image over existing screen state
-        self.current_state.paste(image, (x, y))
-
-        # Rotate image before sending to screen: all images sent to the screen are in portrait mode
-        if self.orientation == Orientation.LANDSCAPE:
-            base_image = self.current_state.transpose(Image.Transpose.ROTATE_270)
-        elif self.orientation == Orientation.REVERSE_LANDSCAPE:
-            base_image = self.current_state.transpose(Image.Transpose.ROTATE_90)
-        elif self.orientation == Orientation.PORTRAIT:
-            base_image = self.current_state.transpose(Image.Transpose.ROTATE_180)
-        else:  # Orientation.REVERSE_PORTRAIT is initial screen orientation
-            base_image = self.current_state
-
-        # Send image data (auto JPEG fallback when payload exceeds device limit)
-        send_pil_image_auto(self.dev, base_image, max_bytes=MAX_IMAGE_PAYLOAD_DEFAULT)
+        # Paste new image over existing screen state; the sender thread pushes the composed
+        # frame to the display at a capped rate (full-frame encode+send per widget is too slow)
+        with self._state_lock:
+            self.current_state.paste(image, (x, y))
+        self._frame_dirty.set()


### PR DESCRIPTION
## Problem

The Turing USB protocol (`REVISION: TUR_USB`, HW rev 1.x models incl. 8.8"/9.2") only supports full-screen image uploads — there is no partial-update command. `LcdCommTuringUSB.DisplayPILImage()` therefore encoded and sent the **entire framebuffer once per widget refresh**. With a typical theme refreshing ~20 widgets per second, and `_encode_png()` using `compress_level=9` (~540 ms CPU per 1920x480 photographic frame), the monitor pinned **3-4 CPU cores** on an 8-core Ryzen (9.2" model, theme with photo background).

Profiled with py-spy: virtually all samples were in `ImageFile._encode_tile` under `DisplayPILImage`, spread across the stat refresh threads.

## Fix

- `DisplayPILImage()` now only pastes the widget into `current_state` (under a lock) and marks the frame dirty — no encode/send per widget.
- A dedicated daemon thread (`TuringUSB_Sender`) sends the composed frame at most every 0.5 s, so any number of widget updates coalesce into <= 2 uploads/sec. Visually nothing changes (stat intervals are >= 1 s).
- A device lock serializes USB access; previously the stat threads wrote to the device concurrently with no synchronization.
- Streamed frames are encoded with `compress_level=1` (~25 ms, still lossless, still well under the 1 MiB payload limit). `upload_file()` storage uploads keep level 9.
- Frames are kept RGBA: converting to RGB makes the firmware render the frame incorrectly (tested on the 9.2" PID 0x0092).

## Measurements (9.2" model, 1920x480 theme with photographic background)

| | CPU (of one core) |
|---|---|
| before | ~340% |
| per-widget sends coalesced | ~55% |
| + `compress_level=1` | **~5%** |

Encode benchmark for one full RGBA frame: level 9 = 538 ms, level 1 = 25 ms (625 KiB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)