### PR TITLE
Add wake-up support for CT88INCH displays

### DIFF
--- a/library/lcd/lcd_comm_rev_c.py
+++ b/library/lcd/lcd_comm_rev_c.py
@@ -139,7 +139,7 @@ class LcdCommRevC(LcdComm):
     def auto_detect_com_port() -> Optional[str]:
         # If sleeping device is detected through serial number or vid/pid, try to wake it up
         for com_port in comports():
-            if com_port.serial_number == 'USB7INCH' or com_port.serial_number == 'CT21INCH':
+            if com_port.serial_number in ('USB7INCH', 'CT21INCH', 'CT88INCH'):
                 LcdCommRevC._wake_up_device(com_port)
             elif com_port.vid == 0x1a86 and com_port.pid == 0xca21:
                 LcdCommRevC._wake_up_device(com_port)


### PR DESCRIPTION
## Description

Add wake-up support for Turing 8.8" displays using the initial hardware revision.

My display reports the following serial device while the screen is sleeping:

- VID: `1A86`
- PID: `CA88`
- Serial number: `CT88INCH`

Opening this COM port wakes the display, after which the display exposes another serial device:

- VID: `0525`
- PID: `A4A7`

This device is then detected as the active display COM port.

## Problem

`auto_detect_com_port()` already handles `USB7INCH` and `CT21INCH` serial devices, but does not handle `CT88INCH`.

As a result, the wake-up procedure is not attempted when the 8.8" display is sleeping, and automatic COM port detection fails.

## Fix

Add `CT88INCH` to the serial-number based wake-up detection.

Tested with hardware revision `C` and version `3.10`.