### PR TITLE
Retry opening the display COM port instead of exiting on first failure

### DIFF
--- a/library/lcd/lcd_comm.py
+++ b/library/lcd/lcd_comm.py
@@ -44,6 +44,12 @@ class Orientation(IntEnum):
     REVERSE_LANDSCAPE = 3
 
 
+# The screen resets itself when the program starts, so its COM port can disappear or change for a
+# few seconds: opening it is retried instead of giving up (and exiting) on the first failure.
+SERIAL_OPEN_ATTEMPTS = 10
+SERIAL_OPEN_RETRY_DELAY = 1  # seconds
+
+
 class LcdComm(ABC):
     def __init__(self, com_port: str = "AUTO", display_width: int = 320, display_height: int = 480,
                  update_queue: Optional[queue.Queue] = None):
@@ -90,28 +96,36 @@ class LcdComm(ABC):
             return self.display_width
 
     def openSerial(self):
-        if self.com_port == 'AUTO':
-            self.com_port = self.auto_detect_com_port()
-            if not self.com_port:
-                logger.error(
-                    "Cannot find COM port automatically, please run Configuration again and select COM port manually")
-                try:
-                    sys.exit(0)
-                except:
-                    os._exit(0)
+        # self.com_port is kept as configured ("AUTO" or a port name): on AUTO the port is
+        # detected again at every attempt, since it can change while the screen resets.
+        for attempt in range(1, SERIAL_OPEN_ATTEMPTS + 1):
+            com_port = self.com_port
+            if com_port == 'AUTO':
+                com_port = self.auto_detect_com_port()
+                if not com_port:
+                    logger.warning(
+                        f"Cannot find COM port automatically, retrying ({attempt}/{SERIAL_OPEN_ATTEMPTS})")
+                    time.sleep(SERIAL_OPEN_RETRY_DELAY)
+                    continue
+                logger.debug(f"Auto detected COM port: {com_port}")
             else:
-                logger.debug(f"Auto detected COM port: {self.com_port}")
-        else:
-            logger.debug(f"Static COM port: {self.com_port}")
+                logger.debug(f"Static COM port: {com_port}")
 
-        try:
-            self.lcd_serial = serial.Serial(self.com_port, 115200, timeout=1, rtscts=True)
-        except Exception as e:
-            logger.error(f"Cannot open COM port {self.com_port}: {e}")
             try:
-                sys.exit(0)
-            except:
-                os._exit(0)
+                self.lcd_serial = serial.Serial(com_port, 115200, timeout=1, rtscts=True)
+                return
+            except Exception as e:
+                logger.warning(
+                    f"Cannot open COM port {com_port}: {e} - retrying ({attempt}/{SERIAL_OPEN_ATTEMPTS})")
+                time.sleep(SERIAL_OPEN_RETRY_DELAY)
+
+        logger.error(
+            f"Cannot open COM port after {SERIAL_OPEN_ATTEMPTS} attempts. If the screen is connected, run "
+            f"Configuration again and select the COM port manually")
+        try:
+            sys.exit(0)
+        except:
+            os._exit(0)
 
     def closeSerial(self):
         if self.lcd_serial is not None:


### PR DESCRIPTION
## Problem

`openSerial()` stops the whole program as soon as the COM port cannot be opened:

```python
except Exception as e:
    logger.error(f"Cannot open COM port {self.com_port}: {e}")
    sys.exit(0)
```

That single attempt is easy to lose at boot. The program resets the screen at startup (`RESET_ON_STARTUP`), which disconnects and reconnects the device, so its COM port disappears for a few seconds and can come back under a different name. When the program is started automatically at logon, it can hit exactly that window and exit, leaving the screen showing nothing until the user starts it again by hand.

Real log of an autostart at boot, on Windows 11 with a Turing 5" (rev C):

```
[DEBUG] Waiting for device COM3 - USB Serial Device (COM3) to be turned ON...
[DEBUG] Detected screen turned ON
[DEBUG] Auto detected COM port: COM4
[ERROR] Cannot open COM port COM4: could not open port 'COM4': FileNotFoundError(2, ...)
```

The port was there again seconds later, and starting the program manually worked.

The same single-attempt logic is used for reconnection at runtime: `WriteLine()` closes and reopens the port on `SerialException`, through this same function.

## Changes

- `openSerial()` retries (10 attempts, 1 second apart) before giving up. Failed attempts are logged as warnings; giving up still logs an error and exits as before.
- `self.com_port` keeps the configured value (`"AUTO"` or a port name) instead of being overwritten by the detected port. With `AUTO`, the port is therefore detected again at every attempt — which matters here, because the screen may come back on a different port than the one detected a moment earlier. Nothing else in the codebase reads `self.com_port`.

## Testing

- Simulated failures with a stubbed `serial.Serial`: opening succeeds after 3 failed attempts, and when every attempt fails the program still exits cleanly with the error message instead of hanging.
- Real hardware (Turing 5" rev C, Windows 11, Python 3.13): normal startup is unaffected.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
