### PR TITLE
Restore display orientation after Windows resume

### DIFF
--- a/library/display.py
+++ b/library/display.py
@@ -139,9 +139,7 @@ class Display:
         # Set backplate RGB LED color (for supported HW only)
         self.lcd.SetBackplateLedColor(config.THEME_DATA['display'].get("DISPLAY_RGB_LED", (255, 255, 255)))
 
-        # The LCD controller may lose its configured orientation during sleep/hibernate.
         orientation = _get_theme_orientation()
-        logger.info("Restoring display orientation: %s" % orientation.name)
         self.lcd.SetOrientation(orientation)
 
     def turn_off(self):

--- a/library/display.py
+++ b/library/display.py
@@ -126,11 +126,8 @@ class Display:
         # Send initialization commands
         self.lcd.InitializeComm()
 
-        # Turn on display, set brightness and LEDs for supported HW
+        # Turn on display, set brightness, LEDs and orientation for supported HW
         self.turn_on()
-
-        # Set orientation
-        self.lcd.SetOrientation(_get_theme_orientation())
 
     def turn_on(self):
         # Turn screen on in case it was turned off previously
@@ -141,6 +138,11 @@ class Display:
 
         # Set backplate RGB LED color (for supported HW only)
         self.lcd.SetBackplateLedColor(config.THEME_DATA['display'].get("DISPLAY_RGB_LED", (255, 255, 255)))
+
+        # The LCD controller may lose its configured orientation during sleep/hibernate.
+        orientation = _get_theme_orientation()
+        logger.info("Restoring display orientation: %s" % orientation.name)
+        self.lcd.SetOrientation(orientation)
 
     def turn_off(self):
         # Turn screen off

--- a/library/lcd/lcd_comm_rev_a.py
+++ b/library/lcd/lcd_comm_rev_a.py
@@ -173,7 +173,9 @@ class LcdCommRevA(LcdComm):
         byteBuffer[8] = (width & 255)
         byteBuffer[9] = (height >> 8)
         byteBuffer[10] = (height & 255)
-        self.serial_write(bytes(byteBuffer))
+        # Serialize orientation with the other display commands. A direct write can race
+        # the queue worker when Windows resumes and scheduled sensor redraws start again.
+        self.SendLine(bytes(byteBuffer))
 
     def DisplayPILImage(
             self,

--- a/main.py
+++ b/main.py
@@ -161,10 +161,17 @@ if __name__ == "__main__":
                     display.turn_off()
                 elif wParam == win32con.PBT_APMRESUMEAUTOMATIC:
                     logger.info("Computer is resuming from sleep, display will turn on")
+                    # Windows may resume the process before the USB/serial endpoint is fully
+                    # ready. Also allow queued pre-suspend writes to finish before restoring
+                    # display state and redrawing the theme.
+                    logger.info("Waiting 1.0s for USB display to settle after resume")
+                    time.sleep(1.0)
+                    wait_for_empty_queue(2)
                     display.turn_on()
                     # Some models have troubles displaying back the previous bitmap after being turned off/on
                     display.display_static_images()
                     display.display_static_text()
+                    logger.info("Resume redraw queued")
             else:
                 # For any other events, the program will stop
                 logger.info("Program will now exit")


### PR DESCRIPTION
## Summary

On Windows, some displays can lose their configured orientation after sleep or hibernation and resume in the default orientation.

This was reproduced on a Turing Smart Screen 3.5" Rev. A using reversed portrait orientation.

The Windows resume handler currently calls `display.turn_on()`, but orientation is only configured separately during initial display initialization. Rev. A also sends `SetOrientation()` directly to the serial port instead of serializing it with the normal display command queue.

This PR:

- restores the configured orientation whenever the display is turned back on;
- queues the Rev. A orientation command with the other display commands;
- waits briefly for the USB/serial device to settle after Windows resume;
- lets pending queued writes finish before restoring the display state;
- redraws the static theme content after recovery.

## Reproduction

Before this change:

1. Configure the display to use reversed portrait orientation.
2. Start the monitor normally and verify the orientation is correct.
3. Put Windows into sleep/hibernate.
4. Resume Windows.

On affected resumes, the display controller can return in its default orientation while the monitoring process continues running. On Rev. A, restoring orientation immediately during resume can also race with queued display updates.

## Why

After hibernation, the LCD controller may return to its default orientation while the application itself continues running.

Sending the orientation command immediately during resume can also race with queued redraw/sensor updates on Rev. A.

Serializing the orientation command and allowing the USB endpoint/queue to settle before redraw makes the resume sequence deterministic.

## Hardware validation

Tested by Mugen Art Lab on:

- Turing Smart Screen 3.5"
- Hardware revision A
- Windows
- reversed portrait orientation (`DISPLAY_REVERSE: true`)

The final recovery sequence was exercised through repeated real-world hibernate/resume cycles, including multi-hour hibernation periods. Orientation, background/static content and live sensor updates recovered correctly after resume.

The final test run completed 6 consecutive long hibernate/resume cycles without an orientation failure or incomplete redraw.

## Notes

The change is intentionally limited to resume/orientation recovery and does not modify theme configuration or sensor logic.